### PR TITLE
 Issue #27: changed parent pom version, set build compability to jdk7 to avoid warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>nz.ac.waikato.cms.moa</groupId>
   <artifactId>moa-pom</artifactId>
   <packaging>pom</packaging>
-  <version>2012.09-SNAPSHOT</version>
+  <version>2015.05-SNAPSHOT</version>
 
   <name>MOA: meta-package</name>
   <description>
@@ -111,6 +111,15 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+	  <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.5</version>
+            <configuration>
+               <source>1.7</source>
+               <target>1.7</target>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/weka-package/pom.xml
+++ b/weka-package/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>nz.ac.waikato.cms.moa</groupId>
     <artifactId>moa-pom</artifactId>
-    <version>2012.09-SNAPSHOT</version>
+    <version>2015.05-SNAPSHOT</version>
   </parent>
 
   <artifactId>weka-package</artifactId>


### PR DESCRIPTION
Hi,
I changed the version in the top level pom to fix the build error.

I also added a plugin to target jdk =1.7 since I get a warnings saying '_' not supported in JDK8. 
Despite these changes, I have to run maven with skip tests true and skip javadocs for the build to complete successfully.

