### PR TITLE
Fix constructor on class Instances

### DIFF
--- a/moa/src/main/java/com/yahoo/labs/samoa/instances/Instances.java
+++ b/moa/src/main/java/com/yahoo/labs/samoa/instances/Instances.java
@@ -129,6 +129,7 @@ public class Instances implements Serializable {
      */
     public Instances(String st, List<Attribute> v, int capacity) {
         this.instanceInformation = new InstanceInformation(st, v);
+        this.instances = new ArrayList<Instance>(capacity);
         this.computeAttributesIndices();
     }
 


### PR DESCRIPTION
Added the following line to Instances(String st, List<Attribute> v, int capacity): 

this.instances = new ArrayList<Instance>(capacity);