### PR TITLE
Bug fix in BasicAUCImbalancedPerformanceEvaluator

### DIFF
--- a/moa/src/main/java/moa/evaluation/BasicAUCImbalancedPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/BasicAUCImbalancedPerformanceEvaluator.java
@@ -106,6 +106,7 @@ public class BasicAUCImbalancedPerformanceEvaluator extends AbstractOptionHandle
 			public Score(double value, int position, boolean isPositive) {
 				this.value = value;
 				this.isPositive = isPositive;
+				this.position = position;
 			}
 
 			/**


### PR DESCRIPTION
Missing class field initialization in Score constructor.