### PR TITLE
Changed ConceptDriftStream interface -> ExampleStream to InstanceStream

### DIFF
--- a/moa/src/main/java/moa/streams/ConceptDriftStream.java
+++ b/moa/src/main/java/moa/streams/ConceptDriftStream.java
@@ -21,7 +21,6 @@ package moa.streams;
 
 import java.util.Random;
 import moa.core.Example;
-import moa.core.InstanceExample;
 
 import com.yahoo.labs.samoa.instances.InstancesHeader;
 import moa.core.ObjectRepository;
@@ -30,7 +29,6 @@ import moa.options.ClassOption;
 import com.github.javacliparser.FloatOption;
 import com.github.javacliparser.IntOption;
 import moa.tasks.TaskMonitor;
-import com.yahoo.labs.samoa.instances.Instance;
 
 /**
  * Stream generator that adds concept drift to examples in a stream.
@@ -49,7 +47,7 @@ import com.yahoo.labs.samoa.instances.Instance;
  * @version $Revision: 7 $
  */
 public class ConceptDriftStream extends AbstractOptionHandler implements
-        ExampleStream {
+        InstanceStream {
 
     @Override
     public String getPurposeString() {


### PR DESCRIPTION
Changed the interface that ConceptDriftStream implements from ExampleStream to InstanceStream to make it compatible with WriteStreamToARFF. Also, it is now aligned with ConceptDriftRealStream (and other generators), which also implements InstanceStream.