### PR TITLE
ClusTree serialization bug fix

### DIFF
--- a/moa/src/main/java/moa/clusterers/clustree/Entry.java
+++ b/moa/src/main/java/moa/clusterers/clustree/Entry.java
@@ -19,7 +19,9 @@
  */
 package moa.clusterers.clustree;
 
-public class Entry {
+import java.io.Serializable;
+
+public class Entry implements Serializable {
 
     /**
      * The actual entry data.

--- a/moa/src/main/java/moa/clusterers/clustree/Node.java
+++ b/moa/src/main/java/moa/clusterers/clustree/Node.java
@@ -20,7 +20,9 @@
 
 package moa.clusterers.clustree;
 
-public class Node {
+import java.io.Serializable;
+
+public class Node implements Serializable {
 
 	final int NUMBER_ENTRIES = 3;
     static int INSERTIONS_BETWEEN_CLEANUPS = 10000;


### PR DESCRIPTION
In order to serialize ClusTree model after training for future use the fields inside it also need to be Serializable. But Node and Entry classes were not serializable and hence throws error when trying to serialize ClusTree. Fixed them by implementing serializable for both classes