### PR TITLE
made kmeans take the weight of the microclusters into account

### DIFF
--- a/moa/src/main/java/moa/clusterers/KMeans.java
+++ b/moa/src/main/java/moa/clusterers/KMeans.java
@@ -102,6 +102,7 @@ public class KMeans {
 
     private static SphereCluster calculateCenter( ArrayList<Cluster> cluster, int dimensions ) {
 	double[] res = new double[dimensions];
+	double totalWeight = 0.0;
 	for ( int i = 0; i < res.length; i++ ) {
 	    res[i] = 0.0;
 	}
@@ -112,14 +113,15 @@ public class KMeans {
 
 	for ( Cluster point : cluster ) {
             double [] center = point.getCenter();
+            totalWeight+=point.getWeight();
             for (int i = 0; i < res.length; i++) {
-               res[i] += center[i];
+               res[i] += (center[i] * point.getWeight());
             }
 	}
 
 	// Normalize
 	for ( int i = 0; i < res.length; i++ ) {
-	    res[i] /= cluster.size();
+	    res[i] /= totalWeight;
 	}
 
 	// Calculate radius


### PR DESCRIPTION
since the kmeans is intended to be used on the micro clustering results from ClusTree or CluStream etc the data points to the kmeans are actually micro clusters which has an associated weight. A dominant micro cluster which has more points in it should be given more weightage when calculating new centers. Also ClusTree handles concept drift by reducing the weight of the micro-clusters. So it is important to use the weights also when finding centers.