### PR TITLE
Accept new values of a nominal attribute found in stream

### DIFF
--- a/moa/src/main/java/com/yahoo/labs/samoa/instances/Attribute.java
+++ b/moa/src/main/java/com/yahoo/labs/samoa/instances/Attribute.java
@@ -242,8 +242,14 @@ public class Attribute implements Serializable {
             }
         }
         Integer val = (Integer) this.valuesStringAttribute.get(value);
+        
+        // in case value was not on a list of unique values of nominal attribute yet, add it
+        // Hence, the list of values can be extended with new entries arriving in the stream
         if (val == null) {
-            return -1;
+          int currentValueCount=this.valuesStringAttribute.size();
+          this.valuesStringAttribute.put(value,currentValueCount);
+          this.attributeValues.add(value);
+          return currentValueCount;
         } else {
             return val.intValue();
         }


### PR DESCRIPTION
As of now, Attribute class assumes all values of a nominal attribute are defined before stream processing starts. However, in case stream data evolves, for some attributes the complete list of attribute values may not be known at the beginning. Hence, apart from declaring a priori all attribute values e.g. in ARFF header, it seems reasonable to gradually add new attribute values once they are encountered in the instances. This extension makes it possible.