### PR TITLE
Create HoeffdingRegressionTree

### DIFF
--- a/moa/src/main/java/moa/classifiers/trees/HoeffdingRegressionTree
+++ b/moa/src/main/java/moa/classifiers/trees/HoeffdingRegressionTree
@@ -1,0 +1,277 @@
+/*
+ *    HoeffdingTree.java
+ *    Copyright (C) 2007 University of Waikato, Hamilton, New Zealand
+ *    @author Richard Kirkby (rkirkby@cs.waikato.ac.nz)
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package moa.classifiers.trees;
+
+
+import moa.classifiers.Regressor;
+
+import com.yahoo.labs.samoa.instances.Instance;
+import moa.classifiers.core.AttributeSplitSuggestion;
+import moa.classifiers.core.attributeclassobservers.AttributeClassObserver;
+import moa.classifiers.core.attributeclassobservers.HoeffdingNominalAttributeClassObserver;
+import moa.classifiers.core.splitcriteria.SplitCriterion;
+import moa.core.AutoExpandVector;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class HoeffdingRegressionTree extends HoeffdingTree  implements Regressor {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String getPurposeString() {
+        return "Hoeffding Regression Tree or VFDT.";
+    }
+
+    public static class InactiveLearningNodeForRegression extends InactiveLearningNode {
+        public InactiveLearningNodeForRegression(double[] initialClassObservations) {
+            super(initialClassObservations);
+        }
+
+        @Override
+        public void learnFromInstance(Instance inst, HoeffdingTree ht) {
+            this.observedClassDistribution.addToValue(0,
+                    1);
+            this.observedClassDistribution.addToValue(1,
+                    inst.classValue());
+            this.observedClassDistribution.addToValue(2,
+                    inst.classValue()* inst.classValue());
+
+
+        }
+    }
+
+    public static class ActiveLearningNodeForRegression extends ActiveLearningNode {
+        public ActiveLearningNodeForRegression(double[] initialClassObservations) {
+            super(initialClassObservations);
+            this.weightSeenAtLastSplitEvaluation = getWeightSeen();
+            this.isInitialized = false;
+        }
+
+        @Override
+        public void learnFromInstance(Instance inst, HoeffdingTree ht) {
+            if (this.isInitialized == false) {
+                this.attributeObservers = new AutoExpandVector<AttributeClassObserver>(inst.numAttributes());
+                this.isInitialized = true;
+            }
+            this.observedClassDistribution.addToValue(0,
+                    1);
+            this.observedClassDistribution.addToValue(1,
+                    inst.classValue());
+            this.observedClassDistribution.addToValue(2,
+                    inst.classValue()* inst.classValue());
+
+            for (int i = 0; i < inst.numAttributes() - 1; i++) {
+                int instAttIndex = modelAttIndexToInstanceAttIndex(i, inst);
+                AttributeClassObserver obs = this.attributeObservers.get(i);
+                if (obs == null) {
+                    obs = inst.attribute(instAttIndex).isNominal() ? ht.newNominalClassObserver() : ht.newNumericClassObserver();
+                    this.attributeObservers.set(i, obs);
+                }
+                obs.observeAttributeTarget(inst.value(instAttIndex),  inst.classValue());
+            }
+        }
+
+        @Override
+        public double getWeightSeen() {
+            return this.observedClassDistribution.getValue(0);
+        }
+
+
+    }
+
+
+    public static class MeanClass extends ActiveLearningNodeForRegression {
+        public MeanClass(double[] initialClassObservations) {
+            super(initialClassObservations);
+
+
+        }
+
+        public static double sum(double[] vecteur) {
+            double result = 0;
+            for (int i = 0; i < vecteur.length; i++) {
+                result += vecteur[i];
+            }
+            return result;
+        }
+
+        @Override
+        public double[] getClassVotes(Instance inst, HoeffdingTree ht) {
+            double numberOfExamplesSeen = 0;
+            double sumOfValues = 0;
+            double prediction = 0;
+            double V[] = super.getClassVotes(inst, ht);
+            sumOfValues = V[1];
+            numberOfExamplesSeen = V[0];
+            //System.out.println(sumOfValues);
+            //System.out.println(numberOfExamplesSeen);
+
+            prediction = sumOfValues / numberOfExamplesSeen;
+            //System.out.println(prediction);
+
+
+            return new double[]{prediction};
+        }
+
+    }
+
+    @Override
+    public double[] getVotesForInstance(Instance inst) {
+        if (this.treeRoot != null) {
+            FoundNode foundNode = this.treeRoot.filterInstanceToLeaf(inst,
+                    null, -1);
+            Node leafNode = foundNode.node;
+            if (leafNode == null) {
+                leafNode = foundNode.parent;
+            }
+            return leafNode.getClassVotes(inst, this);
+
+        } else {
+
+            return new double[]{0};
+        }
+    }
+
+    protected LearningNode newLearningNode(double[] initialClassObservations) {
+
+        return new MeanClass(initialClassObservations);
+
+    }
+
+
+    @Override
+    public void trainOnInstanceImpl(Instance inst) {
+        if (this.treeRoot == null) {
+            this.treeRoot = newLearningNode();
+            this.activeLeafNodeCount = 1;
+        }
+        FoundNode foundNode = this.treeRoot.filterInstanceToLeaf(inst, null, -1);
+        Node leafNode = foundNode.node;
+        if (leafNode == null) {
+            leafNode = newLearningNode();
+            foundNode.parent.setChild(foundNode.parentBranch, leafNode);
+            this.activeLeafNodeCount++;
+        }
+        if (leafNode instanceof LearningNode) {
+            LearningNode learningNode = (LearningNode) leafNode;
+            learningNode.learnFromInstance(inst, this);
+            if (this.growthAllowed
+                    && (learningNode instanceof ActiveLearningNodeForRegression)) {
+                ActiveLearningNodeForRegression activeLearningNode = (ActiveLearningNodeForRegression) learningNode;
+                double weightSeen = activeLearningNode.getWeightSeen();
+                if (weightSeen
+                        - activeLearningNode.getWeightSeenAtLastSplitEvaluation() >= this.gracePeriodOption.getValue()) {
+                    attemptToSplit(activeLearningNode, foundNode.parent,
+                            foundNode.parentBranch);
+                    activeLearningNode.setWeightSeenAtLastSplitEvaluation(weightSeen);
+                }
+            }
+        }
+
+    }
+
+    protected void attemptToSplit(ActiveLearningNode node, SplitNode parent,
+                                  int parentIndex) {
+        if (!node.observedClassDistributionIsPure()) {
+            SplitCriterion splitCriterion = (SplitCriterion) getPreparedClassOption(this.splitCriterionOption);
+            AttributeSplitSuggestion[] bestSplitSuggestions = node.getBestSplitSuggestions(splitCriterion, this);
+            Arrays.sort(bestSplitSuggestions);
+            boolean shouldSplit = false;
+            if (bestSplitSuggestions.length < 2) {
+                shouldSplit = bestSplitSuggestions.length > 0;
+            } else {
+                double hoeffdingBound = computeHoeffdingBound(splitCriterion.getRangeOfMerit(node.getObservedClassDistribution()),
+                        this.splitConfidenceOption.getValue(), node.getWeightSeen());
+                AttributeSplitSuggestion bestSuggestion = bestSplitSuggestions[bestSplitSuggestions.length - 1];
+                AttributeSplitSuggestion secondBestSuggestion = bestSplitSuggestions[bestSplitSuggestions.length - 2];
+                if ((  secondBestSuggestion.merit/bestSuggestion.merit < 1 - hoeffdingBound)
+                        || (hoeffdingBound < this.tieThresholdOption.getValue())) {
+                    shouldSplit = true;
+                    System.out.println(hoeffdingBound<this.tieThresholdOption.getValue());
+                }
+                // }
+                if ((this.removePoorAttsOption != null)
+                        && this.removePoorAttsOption.isSet()) {
+                    Set<Integer> poorAtts = new HashSet<Integer>();
+                    // scan 1 - add any poor to set
+                    for (int i = 0; i < bestSplitSuggestions.length; i++) {
+                        if (bestSplitSuggestions[i].splitTest != null) {
+                            int[] splitAtts = bestSplitSuggestions[i].splitTest.getAttsTestDependsOn();
+                            if (splitAtts.length == 1) {
+                                if (bestSuggestion.merit
+                                        - bestSplitSuggestions[i].merit > hoeffdingBound) {
+                                    poorAtts.add(new Integer(splitAtts[0]));
+                                }
+                            }
+                        }
+                    }
+                    // scan 2 - remove good ones from set
+                    for (int i = 0; i < bestSplitSuggestions.length; i++) {
+                        if (bestSplitSuggestions[i].splitTest != null) {
+                            int[] splitAtts = bestSplitSuggestions[i].splitTest.getAttsTestDependsOn();
+                            if (splitAtts.length == 1) {
+                                if (bestSuggestion.merit
+                                        - bestSplitSuggestions[i].merit < hoeffdingBound) {
+                                    poorAtts.remove(new Integer(splitAtts[0]));
+                                }
+                            }
+                        }
+                    }
+                    for (int poorAtt : poorAtts) {
+                        node.disableAttribute(poorAtt);
+                    }
+                }
+            }
+            if (shouldSplit) {
+
+                AttributeSplitSuggestion splitDecision = bestSplitSuggestions[bestSplitSuggestions.length - 1];
+                if (splitDecision.splitTest == null) {
+                    // preprune - null wins
+                    deactivateLearningNode(node, parent, parentIndex);
+                    System.out.println("SPLIIIIIIIIIT !");
+                } else {
+                    System.out.println("SPLit3");
+                    SplitNode newSplit = newSplitNode(splitDecision.splitTest,
+                            node.getObservedClassDistribution(),splitDecision.numSplits() );
+                    for (int i = 0; i < splitDecision.numSplits(); i++) {
+                        Node newChild = newLearningNode(splitDecision.resultingClassDistributionFromSplit(i));
+                        newSplit.setChild(i, newChild);
+                    }
+                    this.activeLeafNodeCount--;
+                    this.decisionNodeCount++;
+                    this.activeLeafNodeCount += splitDecision.numSplits();
+                    if (parent == null) {
+                        this.treeRoot = newSplit;
+                    } else {
+                        parent.setChild(parentIndex, newSplit);
+                    }
+                }
+                // manage memory
+                enforceTrackerLimit();
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
This HoeffdingRegressionTree needs to be used with HoeffdingNominalAttributeClassObserver and HoeffdinNumericClassObserver in order to handle the categorical and numerical attributes , also   VarianceReductionSplitCriterion needs to be used instead of InfoGainSplitCriterion in order to work properly.