### PR TITLE
HoeffdingResgressionTree

### DIFF
--- a/moa/src/main/java/moa/classifiers/core/attributeclassobservers/HoeffdingNominalAttributeClassObserver.java
+++ b/moa/src/main/java/moa/classifiers/core/attributeclassobservers/HoeffdingNominalAttributeClassObserver.java
@@ -1,0 +1,211 @@
+package moa.classifiers.core.attributeclassobservers;
+
+import moa.classifiers.core.AttributeSplitSuggestion;
+import moa.classifiers.core.conditionaltests.NominalAttributeMultiwayTest;
+import moa.classifiers.core.splitcriteria.SplitCriterion;
+import moa.core.DoubleVector;
+import moa.core.ObjectRepository;
+import moa.options.AbstractOptionHandler;
+import moa.tasks.TaskMonitor;
+import moa.classifiers.core.conditionaltests.NominalAttributeBinaryTest;
+
+import java.io.Serializable;
+
+public class HoeffdingNominalAttributeClassObserver extends AbstractOptionHandler implements
+        DiscreteAttributeClassObserver  {
+
+    private static final long serialVersionUID = 1L;
+
+    protected class Node implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        // The split point to use
+        public double cut_point;
+
+        // statistics
+        public DoubleVector statistics = new DoubleVector();
+
+
+        // Child node
+        public HoeffdingNominalAttributeClassObserver.Node child;
+
+
+        public Node(double val, double label) {
+            this.cut_point = val;
+            this.statistics.addToValue(0, 1);
+            this.statistics.addToValue(1, label);
+            this.statistics.addToValue(2, label * label);
+        }
+
+        /**
+         * Insert a new value into the tree, updating both the sum of values and
+         * sum of squared values arrays
+         */
+        public void insertValue(double val, double label) {
+            //System.out.println(val);
+            // If the new value equals the value stored in a node, update
+            // the  node information
+            if (val == this.cut_point) {
+                this.statistics.addToValue(0, 1);
+                this.statistics.addToValue(1, label);
+                this.statistics.addToValue(2, label * label);
+            } // If the new value is less or greater than the value in a node, send the value down to the  child node.
+            // If no left child exists, create one
+            else  {
+
+                if (this.child == null) {
+                    this.child = new HoeffdingNominalAttributeClassObserver.Node(val, label);
+                    numberOfPossibleValues += 1 ;
+                } else {
+                    this.child.insertValue(val, label);
+                }
+
+            }
+        }
+    }
+
+    // Root node of the tree structure for this attribute
+    protected HoeffdingNominalAttributeClassObserver.Node root = null;
+
+    // Global variables for use in the FindBestSplit algorithm
+    double sumOne;
+    double sumRest;
+    double sumSqOne;
+    double sumSqRest;
+    double countOne;
+    double countRest;
+    double sumTotal;
+    double sumSqTotal;
+    double count ;
+    boolean binaryOnly;
+    int numberOfPossibleValues  ;
+
+    public void observeAttributeClass(double attVal, int classVal, double weight) {
+
+
+    }
+
+    @Override
+    public double probabilityOfAttributeValueGivenClass(double attVal,
+                                                        int classVal) {
+        // TODO: NaiveBayes broken until implemented
+        return 0.0;
+    }
+
+    @Override
+    public AttributeSplitSuggestion getBestEvaluatedSplitSuggestion(SplitCriterion criterion, double[] preSplitDist, int attIndex, boolean binaryOnly) {
+
+        // Initialise global variables
+        sumOne = 0;
+        sumRest = 0;
+        sumSqOne = 0;
+        sumSqRest = 0;
+        countOne = 0;
+        countRest = 0;
+        sumTotal = preSplitDist[1];
+        sumSqTotal = preSplitDist[2];
+        count = preSplitDist[0];
+        this.binaryOnly = binaryOnly;
+        if (binaryOnly) {
+            return searchForBestBinarySplitOption(this.root, null, criterion, attIndex);
+        } else {
+            return searchForBestMultiwaySplitOption(this.root, null, criterion, attIndex);
+        }
+    }
+
+    /**
+     * Implementation of the FindBestSplit algorithm
+     */
+    protected AttributeSplitSuggestion searchForBestBinarySplitOption(HoeffdingNominalAttributeClassObserver.Node currentNode, AttributeSplitSuggestion currentBestOption, SplitCriterion criterion, int attIndex) {
+
+
+
+            // Return null if the current node is null or we have finished looking through all the possible splits
+            if (currentNode == null || countRest == 0.0) {
+                return currentBestOption;
+            }
+
+            if (currentNode.child != null) {
+                currentBestOption = searchForBestBinarySplitOption(currentNode.child, currentBestOption, criterion, attIndex);
+            }
+
+            sumOne = currentNode.statistics.getValue(1);
+            sumRest = sumTotal - sumOne;
+            sumSqOne = currentNode.statistics.getValue(2);
+            sumSqRest = sumSqTotal - sumSqOne;
+            countOne = currentNode.statistics.getValue(0);
+            countRest = count - countOne;
+
+            double[][] postSplitDists = new double[][]{{countOne, sumOne, sumSqOne}, {countRest, sumRest, sumSqRest}};
+            double[] preSplitDist = new double[]{(count), (sumTotal), (sumSqTotal)};
+            double merit = criterion.getMeritOfSplit(preSplitDist, postSplitDists);
+
+            if ((currentBestOption == null) || (merit > currentBestOption.merit)) {
+                currentBestOption = new AttributeSplitSuggestion(
+                        new NominalAttributeBinaryTest(attIndex,
+                                (int) currentNode.cut_point), postSplitDists, merit);
+
+
+            }
+
+        return currentBestOption;
+
+        }
+    protected AttributeSplitSuggestion searchForBestMultiwaySplitOption(HoeffdingNominalAttributeClassObserver.Node currentNode, AttributeSplitSuggestion currentBestOption, SplitCriterion criterion, int attIndex)
+    {
+
+            double[][] postSplitDists = new double[numberOfPossibleValues][3];
+            for (int i = 0; i < numberOfPossibleValues; i++)
+            {
+
+                if (currentNode == null || countRest == 0.0) {
+                    return currentBestOption;
+                }
+                postSplitDists[i][0] = currentNode.statistics.getValue(0);
+                postSplitDists[i][1] =  currentNode.statistics.getValue(1);
+                postSplitDists[i][2] =  currentNode.statistics.getValue(2);
+                currentNode = currentNode.child ;
+
+            }
+            double[] preSplitDist = new double[]{(count), (sumTotal), (sumSqTotal)};
+            double merit = criterion.getMeritOfSplit(preSplitDist, postSplitDists);
+            if ((currentBestOption == null) || (merit > currentBestOption.merit)) {
+                currentBestOption = new AttributeSplitSuggestion(
+                        new NominalAttributeMultiwayTest(attIndex), postSplitDists, merit);
+            }
+
+
+
+        return currentBestOption;
+
+            }
+
+
+
+
+
+
+
+    public void observeAttributeTarget(double attVal, double classVal) {
+        if (Double.isNaN(attVal)) { //Instance.isMissingValue(attVal)
+        } else {
+            if (this.root == null) {
+                numberOfPossibleValues= 1 ;
+                this.root = new HoeffdingNominalAttributeClassObserver.Node(attVal, classVal);
+            } else {
+                this.root.insertValue(attVal, classVal);
+            }
+        }
+    }
+
+    @Override
+    public void getDescription(StringBuilder sb, int indent) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    protected void prepareForUseImpl(TaskMonitor monitor, ObjectRepository repository) {
+        // TODO Auto-generated method stub
+    }
+}

--- a/moa/src/main/java/moa/classifiers/core/attributeclassobservers/HoeffdingNumericAttributeClassObserver.java
+++ b/moa/src/main/java/moa/classifiers/core/attributeclassobservers/HoeffdingNumericAttributeClassObserver.java
@@ -1,0 +1,226 @@
+package moa.classifiers.core.attributeclassobservers;
+
+import moa.classifiers.core.AttributeSplitSuggestion;
+import moa.classifiers.core.conditionaltests.NumericAttributeBinaryTest;
+import moa.classifiers.core.splitcriteria.SplitCriterion;
+import moa.core.DoubleVector;
+import moa.core.ObjectRepository;
+import moa.tasks.TaskMonitor;
+
+import java.io.Serializable;
+
+public class HoeffdingNumericAttributeClassObserver extends BinaryTreeNumericAttributeClassObserver implements NumericAttributeClassObserver {
+    private static final long serialVersionUID = 1L;
+
+    protected class Node implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        // The split point to use
+        public double cut_point;
+
+        // E-BST statistics
+        public DoubleVector leftStatistics = new DoubleVector();
+        public DoubleVector rightStatistics = new DoubleVector();
+
+        // Child nodes
+        public HoeffdingNumericAttributeClassObserver.Node left;
+        public HoeffdingNumericAttributeClassObserver.Node right;
+
+        public Node(double val, double label) {
+            this.cut_point = val;
+            this.leftStatistics.addToValue(0, 1);
+            this.leftStatistics.addToValue(1, label);
+            this.leftStatistics.addToValue(2, label * label);
+        }
+
+        /**
+         * Insert a new value into the tree, updating both the sum of values and
+         * sum of squared values arrays
+         */
+        public void insertValue(double val, double label) {
+
+            // If the new value equals the value stored in a node, update
+            // the left (<=) node information
+            if (val == this.cut_point) {
+                this.leftStatistics.addToValue(0, 1);
+                this.leftStatistics.addToValue(1, label);
+                this.leftStatistics.addToValue(2, label * label);
+            } // If the new value is less than the value in a node, update the
+            // left distribution and send the value down to the left child node.
+            // If no left child exists, create one
+            else if (val <= this.cut_point) {
+                this.leftStatistics.addToValue(0, 1);
+                this.leftStatistics.addToValue(1, label);
+                this.leftStatistics.addToValue(2, label * label);
+                if (this.left == null) {
+                    this.left = new HoeffdingNumericAttributeClassObserver.Node(val, label);
+                } else {
+                    this.left.insertValue(val, label);
+                }
+            } // If the new value is greater than the value in a node, update the
+            // right (>) distribution and send the value down to the right child node.
+            // If no right child exists, create one
+            else { // val > cut_point
+                this.rightStatistics.addToValue(0, 1);
+                this.rightStatistics.addToValue(1, label);
+                this.rightStatistics.addToValue(2, label * label);
+                if (this.right == null) {
+                    this.right = new HoeffdingNumericAttributeClassObserver.Node(val, label);
+                } else {
+                    this.right.insertValue(val, label);
+                }
+            }
+        }
+    }
+
+    // Root node of the E-BST structure for this attribute
+    protected HoeffdingNumericAttributeClassObserver.Node root = null;
+
+    // Global variables for use in the FindBestSplit algorithm
+    double sumTotalLeft;
+    double sumTotalRight;
+    double sumSqTotalLeft;
+    double sumSqTotalRight;
+    double countRightTotal;
+    double countLeftTotal;
+
+    public void observeAttributeClass(double attVal, double classVal, double weight) {
+        if (Double.isNaN(attVal)) { //Instance.isMissingValue(attVal)
+        } else {
+            if (this.root == null) {
+                this.root = new HoeffdingNumericAttributeClassObserver.Node(attVal, classVal);
+            } else {
+                this.root.insertValue(attVal, classVal);
+            }
+        }
+    }
+
+    @Override
+    public double probabilityOfAttributeValueGivenClass(double attVal,
+                                                        int classVal) {
+        // TODO: NaiveBayes broken until implemented
+        return 0.0;
+    }
+
+    @Override
+    public AttributeSplitSuggestion getBestEvaluatedSplitSuggestion(SplitCriterion criterion, double[] preSplitDist, int attIndex, boolean binaryOnly) {
+
+        // Initialise global variables
+        sumTotalLeft = 0;
+        sumTotalRight = preSplitDist[1];
+        sumSqTotalLeft = 0;
+        sumSqTotalRight = preSplitDist[2];
+        countLeftTotal = 0;
+        countRightTotal = preSplitDist[0];
+        return searchForBestSplitOption(this.root, null, criterion, attIndex);
+    }
+
+    /**
+     * Implementation of the FindBestSplit algorithm from E.Ikonomovska et al.
+     */
+    protected AttributeSplitSuggestion searchForBestSplitOption(HoeffdingNumericAttributeClassObserver.Node currentNode, AttributeSplitSuggestion currentBestOption, SplitCriterion criterion, int attIndex) {
+        // Return null if the current node is null or we have finished looking through all the possible splits
+        if (currentNode == null || countRightTotal == 0.0) {
+            return currentBestOption;
+        }
+
+        if (currentNode.left != null) {
+            currentBestOption = searchForBestSplitOption(currentNode.left, currentBestOption, criterion, attIndex);
+        }
+
+        sumTotalLeft += currentNode.leftStatistics.getValue(1);
+        sumTotalRight -= currentNode.leftStatistics.getValue(1);
+        sumSqTotalLeft += currentNode.leftStatistics.getValue(2);
+        sumSqTotalRight -= currentNode.leftStatistics.getValue(2);
+        countLeftTotal += currentNode.leftStatistics.getValue(0);
+        countRightTotal -= currentNode.leftStatistics.getValue(0);
+
+        double[][] postSplitDists = new double[][]{{countLeftTotal, sumTotalLeft, sumSqTotalLeft}, {countRightTotal, sumTotalRight, sumSqTotalRight}};
+        double[] preSplitDist = new double[]{(countLeftTotal + countRightTotal), (sumTotalLeft + sumTotalRight), (sumSqTotalLeft + sumSqTotalRight)};
+        double merit = criterion.getMeritOfSplit(preSplitDist, postSplitDists);
+
+        if ((currentBestOption == null) || (merit > currentBestOption.merit)) {
+            currentBestOption = new AttributeSplitSuggestion(
+                    new NumericAttributeBinaryTest(attIndex,
+                            currentNode.cut_point, true), postSplitDists, merit);
+
+        }
+
+        if (currentNode.right != null) {
+            currentBestOption = searchForBestSplitOption(currentNode.right, currentBestOption, criterion, attIndex);
+        }
+        sumTotalLeft -= currentNode.leftStatistics.getValue(1);
+        sumTotalRight += currentNode.leftStatistics.getValue(1);
+        sumSqTotalLeft -= currentNode.leftStatistics.getValue(2);
+        sumSqTotalRight += currentNode.leftStatistics.getValue(2);
+        countLeftTotal -= currentNode.leftStatistics.getValue(0);
+        countRightTotal += currentNode.leftStatistics.getValue(0);
+
+        return currentBestOption;
+    }
+
+    /**
+     * A method to remove all nodes in the E-BST in which it and all it's
+     * children represent 'bad' split points
+     */
+    public void removeBadSplits(SplitCriterion criterion, double lastCheckRatio, double lastCheckSDR, double lastCheckE) {
+        removeBadSplitNodes(criterion, this.root, lastCheckRatio, lastCheckSDR, lastCheckE);
+    }
+
+    /**
+     * Recursive method that first checks all of a node's children before
+     * deciding if it is 'bad' and may be removed
+     */
+    private boolean removeBadSplitNodes(SplitCriterion criterion, HoeffdingNumericAttributeClassObserver.Node currentNode, double lastCheckRatio, double lastCheckSDR, double lastCheckE) {
+        boolean isBad = false;
+
+        if (currentNode == null) {
+            return true;
+        }
+
+        if (currentNode.left != null) {
+            isBad = removeBadSplitNodes(criterion, currentNode.left, lastCheckRatio, lastCheckSDR, lastCheckE);
+        }
+
+        if (currentNode.right != null && isBad) {
+            isBad = removeBadSplitNodes(criterion, currentNode.left, lastCheckRatio, lastCheckSDR, lastCheckE);
+        }
+
+        if (isBad) {
+
+            double[][] postSplitDists = new double[][]{{currentNode.leftStatistics.getValue(0), currentNode.leftStatistics.getValue(1), currentNode.leftStatistics.getValue(2)}, {currentNode.rightStatistics.getValue(0), currentNode.rightStatistics.getValue(1), currentNode.rightStatistics.getValue(2)}};
+            double[] preSplitDist = new double[]{(currentNode.leftStatistics.getValue(0) + currentNode.rightStatistics.getValue(0)), (currentNode.leftStatistics.getValue(1) + currentNode.rightStatistics.getValue(1)), (currentNode.leftStatistics.getValue(2) + currentNode.rightStatistics.getValue(2))};
+            double merit = criterion.getMeritOfSplit(preSplitDist, postSplitDists);
+
+            if ((merit / lastCheckSDR) < (lastCheckRatio - (2 * lastCheckE))) {
+                currentNode = null;
+                return true;
+            }
+        }
+
+        return false;
+    }
+    public void observeAttributeTarget(double attVal, double classVal) {
+        if (Double.isNaN(attVal)) { //Instance.isMissingValue(attVal)
+        } else {
+            if (this.root == null) {
+                this.root = new HoeffdingNumericAttributeClassObserver.Node(attVal, classVal);
+            } else {
+                this.root.insertValue(attVal, classVal);
+            }
+        }
+    }
+
+    @Override
+    public void getDescription(StringBuilder sb, int indent) {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    protected void prepareForUseImpl(TaskMonitor monitor, ObjectRepository repository) {
+        // TODO Auto-generated method stub
+    }
+}
+
+

--- a/moa/src/main/java/moa/classifiers/trees/HoeffdingRegressionTree.java
+++ b/moa/src/main/java/moa/classifiers/trees/HoeffdingRegressionTree.java
@@ -1,0 +1,282 @@
+/*
+ *    HoeffdingTree.java
+ *    Copyright (C) 2007 University of Waikato, Hamilton, New Zealand
+ *    @author Richard Kirkby (rkirkby@cs.waikato.ac.nz)
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package moa.classifiers.trees;
+
+
+import moa.classifiers.Regressor;
+
+import com.yahoo.labs.samoa.instances.Instance;
+import moa.classifiers.core.AttributeSplitSuggestion;
+import moa.classifiers.core.attributeclassobservers.AttributeClassObserver;
+import moa.classifiers.core.attributeclassobservers.HoeffdingNominalAttributeClassObserver;
+import moa.classifiers.core.splitcriteria.SplitCriterion;
+import moa.core.AutoExpandVector;
+import moa.classifiers.rules.functions.Perceptron;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+
+
+public class HoeffdingRegressionTree extends HoeffdingTree  implements Regressor {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String getPurposeString() {
+        return "Hoeffding Regression Tree or VFDT.";
+    }
+
+
+
+
+
+    public static class InactiveLearningNodeForRegression extends InactiveLearningNode {
+        public InactiveLearningNodeForRegression(double[] initialClassObservations) {
+            super(initialClassObservations);
+        }
+
+        @Override
+        public void learnFromInstance(Instance inst, HoeffdingTree ht) {
+            this.observedClassDistribution.addToValue(0,
+                    1);
+            this.observedClassDistribution.addToValue(1,
+                    inst.classValue());
+            this.observedClassDistribution.addToValue(2,
+                    inst.classValue()* inst.classValue());
+
+
+        }
+    }
+
+    public static class ActiveLearningNodeForRegression extends ActiveLearningNode {
+        public ActiveLearningNodeForRegression(double[] initialClassObservations) {
+            super(initialClassObservations);
+            this.weightSeenAtLastSplitEvaluation = getWeightSeen();
+            this.isInitialized = false;
+        }
+
+        @Override
+        public void learnFromInstance(Instance inst, HoeffdingTree ht) {
+            if (this.isInitialized == false) {
+                this.attributeObservers = new AutoExpandVector<AttributeClassObserver>(inst.numAttributes());
+                this.isInitialized = true;
+            }
+            this.observedClassDistribution.addToValue(0,
+                    1);
+            this.observedClassDistribution.addToValue(1,
+                    inst.classValue());
+            this.observedClassDistribution.addToValue(2,
+                    inst.classValue()* inst.classValue());
+
+            for (int i = 0; i < inst.numAttributes() - 1; i++) {
+                int instAttIndex = modelAttIndexToInstanceAttIndex(i, inst);
+                AttributeClassObserver obs = this.attributeObservers.get(i);
+                if (obs == null) {
+                    obs = inst.attribute(instAttIndex).isNominal() ? ht.newNominalClassObserver() : ht.newNumericClassObserver();
+                    this.attributeObservers.set(i, obs);
+                }
+                obs.observeAttributeTarget(inst.value(instAttIndex),  inst.classValue());
+            }
+        }
+
+        @Override
+        public double getWeightSeen() {
+            return this.observedClassDistribution.getValue(0);
+        }
+
+
+    }
+
+
+    public static class MeanClass extends ActiveLearningNodeForRegression {
+        public MeanClass(double[] initialClassObservations) {
+            super(initialClassObservations);
+
+
+        }
+
+        public static double sum(double[] vecteur) {
+            double result = 0;
+            for (int i = 0; i < vecteur.length; i++) {
+                result += vecteur[i];
+            }
+            return result;
+        }
+
+        @Override
+        public double[] getClassVotes(Instance inst, HoeffdingTree ht) {
+            double numberOfExamplesSeen = 0;
+            double sumOfValues = 0;
+            double prediction = 0;
+            double V[] = super.getClassVotes(inst, ht);
+            sumOfValues = V[1];
+            numberOfExamplesSeen = V[0];
+
+
+            prediction = sumOfValues / numberOfExamplesSeen;
+
+
+
+            return new double[]{prediction};
+        }
+
+    }
+
+    @Override
+    public double[] getVotesForInstance(Instance inst) {
+        if (this.treeRoot != null) {
+            FoundNode foundNode = this.treeRoot.filterInstanceToLeaf(inst,
+                    null, -1);
+            Node leafNode = foundNode.node;
+            if (leafNode == null) {
+                leafNode = foundNode.parent;
+            }
+            return leafNode.getClassVotes(inst, this);
+
+        } else {
+
+            return new double[]{0};
+        }
+    }
+
+    protected LearningNode newLearningNode(double[] initialClassObservations) {
+
+        return new MeanClass(initialClassObservations);
+
+    }
+
+
+    @Override
+    public void trainOnInstanceImpl(Instance inst) {
+        if (this.treeRoot == null) {
+            this.treeRoot = newLearningNode();
+            this.activeLeafNodeCount = 1;
+        }
+        FoundNode foundNode = this.treeRoot.filterInstanceToLeaf(inst, null, -1);
+        Node leafNode = foundNode.node;
+        if (leafNode == null) {
+            leafNode = newLearningNode();
+            foundNode.parent.setChild(foundNode.parentBranch, leafNode);
+            this.activeLeafNodeCount++;
+        }
+        if (leafNode instanceof LearningNode) {
+            LearningNode learningNode = (LearningNode) leafNode;
+            learningNode.learnFromInstance(inst, this);
+            if (this.growthAllowed
+                    && (learningNode instanceof ActiveLearningNodeForRegression)) {
+                ActiveLearningNodeForRegression activeLearningNode = (ActiveLearningNodeForRegression) learningNode;
+                double weightSeen = activeLearningNode.getWeightSeen();
+                if (weightSeen
+                        - activeLearningNode.getWeightSeenAtLastSplitEvaluation() >= this.gracePeriodOption.getValue()) {
+                    attemptToSplit(activeLearningNode, foundNode.parent,
+                            foundNode.parentBranch);
+                    activeLearningNode.setWeightSeenAtLastSplitEvaluation(weightSeen);
+                }
+            }
+        }
+
+    }
+
+    protected void attemptToSplit(ActiveLearningNode node, SplitNode parent,
+                                  int parentIndex) {
+        if (!node.observedClassDistributionIsPure()) {
+            SplitCriterion splitCriterion = (SplitCriterion) getPreparedClassOption(this.splitCriterionOption);
+            AttributeSplitSuggestion[] bestSplitSuggestions = node.getBestSplitSuggestions(splitCriterion, this);
+            Arrays.sort(bestSplitSuggestions);
+            boolean shouldSplit = false;
+            if (bestSplitSuggestions.length < 2) {
+                shouldSplit = bestSplitSuggestions.length > 0;
+            } else {
+                double hoeffdingBound = computeHoeffdingBound(splitCriterion.getRangeOfMerit(node.getObservedClassDistribution()),
+                        this.splitConfidenceOption.getValue(), node.getWeightSeen());
+                AttributeSplitSuggestion bestSuggestion = bestSplitSuggestions[bestSplitSuggestions.length - 1];
+                AttributeSplitSuggestion secondBestSuggestion = bestSplitSuggestions[bestSplitSuggestions.length - 2];
+                if ((  secondBestSuggestion.merit/bestSuggestion.merit < 1 - hoeffdingBound)
+                        || (hoeffdingBound < this.tieThresholdOption.getValue())) {
+                    shouldSplit = true;
+                    System.out.println(hoeffdingBound<this.tieThresholdOption.getValue());
+                }
+                // }
+                if ((this.removePoorAttsOption != null)
+                        && this.removePoorAttsOption.isSet()) {
+                    Set<Integer> poorAtts = new HashSet<Integer>();
+                    // scan 1 - add any poor to set
+                    for (int i = 0; i < bestSplitSuggestions.length; i++) {
+                        if (bestSplitSuggestions[i].splitTest != null) {
+                            int[] splitAtts = bestSplitSuggestions[i].splitTest.getAttsTestDependsOn();
+                            if (splitAtts.length == 1) {
+                                if (bestSuggestion.merit
+                                        - bestSplitSuggestions[i].merit > hoeffdingBound) {
+                                    poorAtts.add(new Integer(splitAtts[0]));
+                                }
+                            }
+                        }
+                    }
+                    // scan 2 - remove good ones from set
+                    for (int i = 0; i < bestSplitSuggestions.length; i++) {
+                        if (bestSplitSuggestions[i].splitTest != null) {
+                            int[] splitAtts = bestSplitSuggestions[i].splitTest.getAttsTestDependsOn();
+                            if (splitAtts.length == 1) {
+                                if (bestSuggestion.merit
+                                        - bestSplitSuggestions[i].merit < hoeffdingBound) {
+                                    poorAtts.remove(new Integer(splitAtts[0]));
+                                }
+                            }
+                        }
+                    }
+                    for (int poorAtt : poorAtts) {
+                        node.disableAttribute(poorAtt);
+                    }
+                }
+            }
+            if (shouldSplit) {
+
+                AttributeSplitSuggestion splitDecision = bestSplitSuggestions[bestSplitSuggestions.length - 1];
+                if (splitDecision.splitTest == null) {
+                    // preprune - null wins
+                    deactivateLearningNode(node, parent, parentIndex);
+
+                } else {
+                    
+                    SplitNode newSplit = newSplitNode(splitDecision.splitTest,
+                            node.getObservedClassDistribution(),splitDecision.numSplits() );
+                    for (int i = 0; i < splitDecision.numSplits(); i++) {
+                        Node newChild = newLearningNode(splitDecision.resultingClassDistributionFromSplit(i));
+                        newSplit.setChild(i, newChild);
+                    }
+                    this.activeLeafNodeCount--;
+                    this.decisionNodeCount++;
+                    this.activeLeafNodeCount += splitDecision.numSplits();
+                    if (parent == null) {
+                        this.treeRoot = newSplit;
+                    } else {
+                        parent.setChild(parentIndex, newSplit);
+                    }
+                }
+                // manage memory
+                enforceTrackerLimit();
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
This HoeffdingRegressionTree needs to be used with HoeffdingNominalAttributeClassObserver and HoeffdinNumericClassObserver in order to handle the categorical and numerical attributes , also VarianceReductionSplitCriterion needs to be used instead of InfoGainSplitCriterion in order to work properly.

