### PR TITLE
Table instead of text field for data previews

### DIFF
--- a/moa/src/main/java/moa/evaluation/preview/LearningCurve.java
+++ b/moa/src/main/java/moa/evaluation/preview/LearningCurve.java
@@ -22,7 +22,6 @@ package moa.evaluation.preview;
 import java.util.ArrayList;
 import java.util.List;
 
-import moa.AbstractMOAObject;
 import moa.core.DoubleVector;
 import moa.core.Measurement;
 import moa.core.StringUtils;
@@ -34,7 +33,7 @@ import moa.evaluation.LearningEvaluation;
  * @author Richard Kirkby (rkirkby@cs.waikato.ac.nz)
  * @version $Revision: 7 $
  */
-public class LearningCurve extends AbstractMOAObject {
+public class LearningCurve extends Preview {
 
     private static final long serialVersionUID = 1L;
 
@@ -42,8 +41,15 @@ public class LearningCurve extends AbstractMOAObject {
 
     protected List<double[]> measurementValues = new ArrayList<double[]>();
 
+    Class<?> taskClass = null;
+    
     public LearningCurve(String orderingMeasurementName) {
         this.measurementNames.add(orderingMeasurementName);
+    }
+    
+    public LearningCurve(String orderingMeasurementName, Class<?> taskClass) {
+        this.measurementNames.add(orderingMeasurementName);
+        this.taskClass = taskClass;
     }
 
     public String getOrderingMeasurementName() {
@@ -148,4 +154,32 @@ public class LearningCurve extends AbstractMOAObject {
     public int getEntryMeasurementCount(int entryIdx) {
         return this.measurementValues.get(entryIdx).length;
     }
+
+	@Override
+	public Class<?> getTaskClass() {
+		return taskClass;
+	}
+
+	@Override
+	public double[] getEntryData(int entryIndex) {
+		// get the number of measurements
+		int numMeasurements = getMeasurementNameCount();
+
+		int numEntryMeasurements = getEntryMeasurementCount(entryIndex);
+		// preallocate the array to store all measurements
+		double[] data = new double[numMeasurements];
+		// get measuements from the learning curve
+		for(int measurementIdx = 0; measurementIdx < numMeasurements; ++measurementIdx)
+		{
+			if(measurementIdx < numEntryMeasurements)
+			{
+				data[measurementIdx] = getMeasurement(entryIndex, measurementIdx);	
+			}
+			else
+			{
+				data[measurementIdx] = Double.NaN;
+			}
+		}
+		return data;
+	}
 }

--- a/moa/src/main/java/moa/gui/PreviewPanel.java
+++ b/moa/src/main/java/moa/gui/PreviewPanel.java
@@ -63,7 +63,7 @@ public class PreviewPanel extends JPanel implements ResultPreviewListener {
 
     protected JLabel autoRefreshLabel = new JLabel("Auto refresh: ");
 
-    protected JComboBox autoRefreshComboBox = new JComboBox(autoFreqStrings);
+    protected JComboBox<String> autoRefreshComboBox = new JComboBox<String>(autoFreqStrings);
 
     protected TaskTextViewerPanel textViewerPanel; // = new TaskTextViewerPanel();
 
@@ -149,46 +149,20 @@ public class PreviewPanel extends JPanel implements ResultPreviewListener {
         }
     }
 
-//    public void setLatestPreview(Object preview) {
-//        if ((this.previewedThread != null) && this.previewedThread.isComplete()) {
-//            this.previewLabel.setText("Final result");
-//            Object finalResult = this.previewedThread.getFinalResult();
-//            this.textViewerPanel.setText(finalResult != null ? finalResult.toString() : null);
-//            disableRefresh();
-//        } else {
-//            double grabTime = this.previewedThread != null ? this.previewedThread.getLatestPreviewGrabTimeSeconds()
-//                    : 0.0;
-//            String grabString = grabTime > 0.0 ? (" ("
-//                    + StringUtils.secondsToDHMSString(grabTime) + ")") : "";
-//            this.textViewerPanel.setText(preview != null ? preview.toString()
-//                    : null);
-//            if (preview == null) {
-//                this.previewLabel.setText("No preview available" + grabString);
-//            } else {
-//                this.previewLabel.setText("Preview" + grabString);
-//            }
-//        }
-//    }
-
     /**
      * Requests the latest preview and sends it to the TextViewerPanel to
      * display it.
      */
     private void setLatestPreview() {
-
-    	
-    	if(this.previewedThread != null && this.previewedThread.failed())
-    	{
+    	if(this.previewedThread != null && this.previewedThread.isFailed()) {
+    		// failed task
     		FailedTaskReport failedTaskReport = (FailedTaskReport) this.previewedThread.getFinalResult();
     		this.textViewerPanel.setErrorText(failedTaskReport);
     		this.textViewerPanel.setGraph(null);
-    	}
-    	else
-    	{
+    	} else {
         	Preview preview = null;
     		if ((this.previewedThread != null) && this.previewedThread.isComplete()) {
-    			// cancelled, completed or failed task
-    			// TODO if the task is failed, the finalResult is a FailedTaskReport, which is not a Preview
+    			// cancelled or completed task
     			preview = (Preview) this.previewedThread.getFinalResult();
     			this.previewLabel.setText("Final result");
     			disableRefresh();

--- a/moa/src/main/java/moa/gui/PreviewPanel.java
+++ b/moa/src/main/java/moa/gui/PreviewPanel.java
@@ -32,7 +32,7 @@ import moa.core.StringUtils;
 import moa.evaluation.Accuracy;
 import moa.evaluation.ChangeDetectionMeasures;
 import moa.evaluation.MeasureCollection;
-import moa.evaluation.Preview;
+import moa.evaluation.preview.Preview;
 import moa.evaluation.RegressionAccuracy;
 import moa.gui.conceptdrift.CDTaskManagerPanel;
 import moa.tasks.FailedTaskReport;

--- a/moa/src/main/java/moa/gui/TaskTextViewerPanel.java
+++ b/moa/src/main/java/moa/gui/TaskTextViewerPanel.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Scanner;
 
 import javax.swing.JButton;
-import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
@@ -50,7 +49,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
 import moa.evaluation.MeasureCollection;
-import moa.evaluation.Preview;
+import moa.evaluation.preview.Preview;
 import moa.gui.PreviewPanel.TypePanel;
 import moa.gui.conceptdrift.CDTaskManagerPanel;
 import moa.streams.clustering.ClusterEvent;

--- a/moa/src/main/java/moa/gui/TaskTextViewerPanel.java
+++ b/moa/src/main/java/moa/gui/TaskTextViewerPanel.java
@@ -16,24 +16,15 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program. If not, see <http://www.gnu.org/licenses/>.
- *    
+ *
  */
 package moa.gui;
 
-import moa.evaluation.MeasureCollection;
-import moa.gui.PreviewPanel.TypePanel;
-import moa.gui.conceptdrift.CDTaskManagerPanel;
-import moa.streams.clustering.ClusterEvent;
-import moa.tasks.ConceptDriftMainTask;
-import nz.ac.waikato.cms.gui.core.BaseFileChooser;
-
-import javax.swing.JButton;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
@@ -45,6 +36,28 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Scanner;
+
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTable;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+
+import moa.evaluation.MeasureCollection;
+import moa.evaluation.Preview;
+import moa.gui.PreviewPanel.TypePanel;
+import moa.gui.conceptdrift.CDTaskManagerPanel;
+import moa.streams.clustering.ClusterEvent;
+import moa.tasks.ConceptDriftMainTask;
+import moa.tasks.FailedTaskReport;
+
+import nz.ac.waikato.cms.gui.core.BaseFileChooser;
 
 /**
  * This panel displays text. Used to output the results of tasks.
@@ -58,9 +71,15 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
 
     public static String exportFileExtension = "txt";
 
-    protected JTextArea textArea;
+    private PreviewTableModel previewTableModel;
 
-    protected JScrollPane scrollPane;
+    private JTable previewTable;
+
+	private JTextArea errorTextField;
+
+    private JScrollPane scrollPaneTable;
+
+    private JScrollPane scrollPaneText;
 
     protected JButton exportButton;
 
@@ -70,9 +89,9 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
 
    //Added for stream events
     protected CDTaskManagerPanel taskManagerPanel;
-    
+
     protected TypePanel typePanel;
-    
+
     public void initVisualEvalPanel() {
         acc1[0] = getNewMeasureCollection();
         acc2[0] = getNewMeasureCollection();
@@ -81,36 +100,62 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
         }
         clusteringVisualEvalPanel1 = new moa.gui.clustertab.ClusteringVisualEvalPanel();
         clusteringVisualEvalPanel1.setMeasures(acc1, acc2, this);
-        this.graphCanvas.setGraph(acc1[0], acc2[0], 0, 1000); 
+        this.graphCanvas.setGraph(acc1[0], acc2[0], 0, 1000);
         this.graphCanvas.forceAddEvents();
         clusteringVisualEvalPanel1.setMinimumSize(new java.awt.Dimension(280, 118));
         clusteringVisualEvalPanel1.setPreferredSize(new java.awt.Dimension(290, 115));
          panelEvalOutput.add(clusteringVisualEvalPanel1, gridBagConstraints);
     }
-        public TaskTextViewerPanel() {
-           this(TypePanel.CLASSIFICATION, null);
-        }
-        
-        public java.awt.GridBagConstraints gridBagConstraints;
-        
-        public TaskTextViewerPanel(PreviewPanel.TypePanel typePanel, CDTaskManagerPanel taskManagerPanel) { 
-        this.typePanel = typePanel;
-        this.taskManagerPanel = taskManagerPanel;
-        jSplitPane1 = new javax.swing.JSplitPane();
-        topWrapper = new javax.swing.JPanel();
 
-        this.textArea = new JTextArea();
-        this.textArea.setEditable(false);
-        this.textArea.setFont(new Font("Monospaced", Font.PLAIN, 12));
+    public TaskTextViewerPanel() {
+       this(TypePanel.CLASSIFICATION, null);
+    }
+
+    public java.awt.GridBagConstraints gridBagConstraints;
+
+    public TaskTextViewerPanel(PreviewPanel.TypePanel typePanel, CDTaskManagerPanel taskManagerPanel) {
+        this.typePanel = typePanel;
+		this.taskManagerPanel = taskManagerPanel;
+		topWrapper = new javax.swing.JPanel();
+
+		setLayout(new GridBagLayout());
+
+		// mainPane contains the two main components of the text viewer panel:
+		// top component: preview table panel
+		// bottom component: interactive graph panel
+		this.jSplitPane1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
+		this.jSplitPane1.setDividerLocation(200);
+
+		// topWrapper is the wrapper of the top component of mainPane
+		this.topWrapper = new JPanel();
+		this.topWrapper.setLayout(new BorderLayout());
+
+		// previewTable displays live results in table form
+		// (or in text form, if an error occurs)
+		this.previewTableModel = new PreviewTableModel();
+		this.previewTable = new JTable(this.previewTableModel);
+		this.previewTable.setFont(new Font("Monospaced", Font.PLAIN, 12));
+		this.previewTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+
+		this.errorTextField = new JTextArea();
+		this.errorTextField.setEditable(false);
+		this.errorTextField.setFont(new Font("Monospaced", Font.PLAIN, 12));
+
+		// scrollPane enables scroll support for previewTable
+		this.scrollPaneTable = new JScrollPane(this.previewTable, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		this.scrollPaneText = new JScrollPane(this.errorTextField, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		this.scrollPaneText.setVisible(false);
+
+		this.topWrapper.add(this.scrollPaneTable, BorderLayout.CENTER);
+
         this.exportButton = new JButton("Export as .txt file...");
-        this.exportButton.setEnabled(false);
-        JPanel buttonPanel = new JPanel();
-        buttonPanel.setLayout(new GridLayout(1, 2));
-        buttonPanel.add(this.exportButton);
-        topWrapper.setLayout(new BorderLayout());
-        this.scrollPane = new JScrollPane(this.textArea);
-        topWrapper.add(this.scrollPane, BorderLayout.CENTER);
-        topWrapper.add(buttonPanel, BorderLayout.SOUTH);
+		this.exportButton.setEnabled(false);
+		JPanel buttonPanel = new JPanel();
+		buttonPanel.setLayout(new GridLayout(1, 2));
+		buttonPanel.add(this.exportButton);
+		topWrapper.add(buttonPanel, BorderLayout.SOUTH);
         this.exportButton.addActionListener(new ActionListener() {
 
             public void actionPerformed(ActionEvent e) {
@@ -128,7 +173,16 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
                     try {
                         PrintWriter out = new PrintWriter(new BufferedWriter(
                                 new FileWriter(fileName)));
-                        out.write(TaskTextViewerPanel.this.textArea.getText());
+
+                        String text = "";
+
+						if (scrollPaneTable.isVisible()) {
+							text = previewTableModel.toString();
+						} else {
+							text = errorTextField.getText();
+						}
+
+						out.write(text);
                         out.close();
                     } catch (IOException ioe) {
                         GUIUtils.showExceptionDialog(
@@ -295,13 +349,95 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
 
     }
 
-    public void setText(String newText) {
-        Point p = this.scrollPane.getViewport().getViewPosition();
-        this.textArea.setText(newText);
-        this.scrollPane.getViewport().setViewPosition(p);
-        this.exportButton.setEnabled(newText != null);
-        setGraph(newText);
-    }
+    /**
+	 * Updates the preview table based on the information given by preview.
+	 *
+	 * @param preview
+	 *            the new information used to update the table
+	 */
+     public void setText(Preview preview) {
+ 		Point p = this.scrollPaneTable.getViewport().getViewPosition();
+
+ 		previewTableModel.setPreview(preview);
+ 		SwingUtilities.invokeLater(new Runnable() {
+ 			boolean structureChanged = previewTableModel.structureChanged();
+
+ 			public void run() {
+ 				if (!scrollPaneTable.isVisible()) {
+ 					topWrapper.remove(scrollPaneText);
+ 					scrollPaneText.setVisible(false);
+ 					topWrapper.add(scrollPaneTable, BorderLayout.CENTER);
+ 					scrollPaneTable.setVisible(true);
+ 					topWrapper.validate();
+ 				}
+
+ 				if (structureChanged) {
+ 					previewTableModel.fireTableStructureChanged();
+ 					rescaleTableColumns();
+ 				} else {
+ 					previewTableModel.fireTableDataChanged();
+ 				}
+ 				previewTable.repaint();
+ 			}
+ 		});
+
+ 		this.scrollPaneTable.getViewport().setViewPosition(p);
+ 		this.exportButton.setEnabled(preview != null);
+ 	}
+
+    /**
+	 * Displays the error message.
+	 * @param failedTaskReport error message
+	 */
+	public void setErrorText(FailedTaskReport failedTaskReport) {
+		Point p = this.scrollPaneText.getViewport().getViewPosition();
+
+		final String failedTaskReportString = failedTaskReport == null ?
+				"Failed Task Report is null" : failedTaskReport.toString();
+
+		SwingUtilities.invokeLater(
+			new Runnable(){
+				public void run(){
+					if(!scrollPaneText.isVisible())
+					{
+						topWrapper.remove(scrollPaneTable);
+						scrollPaneTable.setVisible(false);
+						topWrapper.add(scrollPaneText, BorderLayout.CENTER);
+						scrollPaneText.setVisible(true);
+						topWrapper.validate();
+					}
+					errorTextField.setText(failedTaskReportString);
+					errorTextField.repaint();
+				}
+			}
+		);
+
+		this.scrollPaneText.getViewport().setViewPosition(p);
+		this.exportButton.setEnabled(failedTaskReport != null);
+	}
+
+	private void rescaleTableColumns() {
+		// iterate over all columns to resize them individually
+		TableColumnModel columnModel = previewTable.getColumnModel();
+		for (int columnIdx = 0; columnIdx < columnModel.getColumnCount(); ++columnIdx) {
+			// get the current column
+			TableColumn column = columnModel.getColumn(columnIdx);
+			// get the renderer for the column header to calculate the preferred
+			// with for the header
+			TableCellRenderer renderer = column.getHeaderRenderer();
+			// check if the renderer is null
+			if (renderer == null) {
+				// if it is null use the default renderer for header
+				renderer = previewTable.getTableHeader().getDefaultRenderer();
+			}
+			// create a cell to calculate its preferred size
+			Component comp = renderer.getTableCellRendererComponent(previewTable, column.getHeaderValue(), false, false,
+					0, columnIdx);
+			int width = comp.getPreferredSize().width;
+			// set the maximum width which was calculated
+			column.setPreferredWidth(width);
+		}
+	}
 
     protected MeasureCollection[] acc1 = new MeasureCollection[1];
 
@@ -401,7 +537,7 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
             } else {
                 this.acc2[0] = getNewMeasureCollection();
             }
-
+            scanner.close();
         } else {
             this.acc1[0] = getNewMeasureCollection();
             this.acc2[0] = getNewMeasureCollection();
@@ -456,104 +592,105 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
         // TODO add your handling code here:
     }//GEN-LAST:event_buttonRunActionPerformed
 
-    // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.JButton buttonRun;
+	// Variables declaration - do not modify//GEN-BEGIN:variables
+	private javax.swing.JButton buttonRun;
 
-    private javax.swing.JButton buttonScreenshot;
+	private javax.swing.JButton buttonScreenshot;
 
-    private javax.swing.JButton buttonStop;
+	private javax.swing.JButton buttonStop;
 
-    private javax.swing.JButton buttonZoomInX;
+	private javax.swing.JButton buttonZoomInX;
 
-    private javax.swing.JButton buttonZoomInY;
+	private javax.swing.JButton buttonZoomInY;
 
-    private javax.swing.JButton buttonZoomOutX;
+	private javax.swing.JButton buttonZoomOutX;
 
-    private javax.swing.JButton buttonZoomOutY;
+	private javax.swing.JButton buttonZoomOutY;
 
-    private javax.swing.JCheckBox checkboxDrawClustering;
+	private javax.swing.JCheckBox checkboxDrawClustering;
 
-    private javax.swing.JCheckBox checkboxDrawGT;
+	private javax.swing.JCheckBox checkboxDrawGT;
 
-    private javax.swing.JCheckBox checkboxDrawMicro;
+	private javax.swing.JCheckBox checkboxDrawMicro;
 
-    private javax.swing.JCheckBox checkboxDrawPoints;
+	private javax.swing.JCheckBox checkboxDrawPoints;
 
-    private moa.gui.clustertab.ClusteringVisualEvalPanel clusteringVisualEvalPanel1;
+	private moa.gui.clustertab.ClusteringVisualEvalPanel clusteringVisualEvalPanel1;
 
-    private javax.swing.JComboBox comboX;
+	private javax.swing.JComboBox comboX;
 
-    private javax.swing.JComboBox comboY;
+	private javax.swing.JComboBox comboY;
 
-    private moa.gui.visualization.GraphCanvas graphCanvas;
+	private moa.gui.visualization.GraphCanvas graphCanvas;
 
-    private javax.swing.JPanel graphPanel;
+	private javax.swing.JPanel graphPanel;
 
-    private javax.swing.JPanel graphPanelControlBottom;
+	private javax.swing.JPanel graphPanelControlBottom;
 
-    private javax.swing.JPanel graphPanelControlTop;
+	private javax.swing.JPanel graphPanelControlTop;
 
-    private javax.swing.JScrollPane graphScrollPanel;
+	private javax.swing.JScrollPane graphScrollPanel;
 
-    private javax.swing.JLabel jLabel1;
+	private javax.swing.JLabel jLabel1;
 
-    private javax.swing.JLabel labelEvents;
+	private javax.swing.JLabel labelEvents;
 
-    private javax.swing.JLabel labelNumPause;
+	private javax.swing.JLabel labelNumPause;
 
-    private javax.swing.JLabel labelX;
+	private javax.swing.JLabel labelX;
 
-    private javax.swing.JLabel labelY;
+	private javax.swing.JLabel labelY;
 
-    private javax.swing.JLabel label_processed_points;
+	private javax.swing.JLabel label_processed_points;
 
-    private javax.swing.JLabel label_processed_points_value;
+	private javax.swing.JLabel label_processed_points_value;
 
-    private javax.swing.JTextField numPauseAfterPoints;
+	private javax.swing.JTextField numPauseAfterPoints;
 
-    private javax.swing.JPanel panelControl;
+	private javax.swing.JPanel panelControl;
 
-    private javax.swing.JPanel panelEvalOutput;
+	private javax.swing.JPanel panelEvalOutput;
 
-    private javax.swing.JPanel panelVisualWrapper;
+	private javax.swing.JPanel panelVisualWrapper;
 
-    private javax.swing.JScrollPane scrollPane0;
+	private javax.swing.JScrollPane scrollPane0;
 
-    private javax.swing.JScrollPane scrollPane1;
+	private javax.swing.JScrollPane scrollPane1;
 
-    private javax.swing.JSlider speedSlider;
+	private javax.swing.JSlider speedSlider;
 
-    private javax.swing.JSplitPane splitVisual;
+	private javax.swing.JSplitPane splitVisual;
 
-    private moa.gui.visualization.StreamPanel streamPanel0;
+	private moa.gui.visualization.StreamPanel streamPanel0;
 
-    private moa.gui.visualization.StreamPanel streamPanel1;
+	private moa.gui.visualization.StreamPanel streamPanel1;
 
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        //reacte on graph selection and find out which measure was selected
-        int selected = Integer.parseInt(e.getActionCommand());
-        int counter = selected;
-        int m_select = 0;
-        int m_select_offset = 0;
-        boolean found = false;
-        for (int i = 0; i < acc1.length; i++) {
-            for (int j = 0; j < acc1[i].getNumMeasures(); j++) {
-                if (acc1[i].isEnabled(j)) {
-                    counter--;
-                    if (counter < 0) {
-                        m_select = i;
-                        m_select_offset = j;
-                        found = true;
-                        break;
-                    }
-                }
-            }
-            if (found) {
-                break;
-            }
-        }
-        this.graphCanvas.setGraph(acc1[m_select], acc2[m_select], m_select_offset, this.graphCanvas.getProcessFrequency());
-        this.graphCanvas.forceAddEvents();
-    }
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		// reacte on graph selection and find out which measure was selected
+		int selected = Integer.parseInt(e.getActionCommand());
+		int counter = selected;
+		int m_select = 0;
+		int m_select_offset = 0;
+		boolean found = false;
+		for (int i = 0; i < acc1.length; i++) {
+			for (int j = 0; j < acc1[i].getNumMeasures(); j++) {
+				if (acc1[i].isEnabled(j)) {
+					counter--;
+					if (counter < 0) {
+						m_select = i;
+						m_select_offset = j;
+						found = true;
+						break;
+					}
+				}
+			}
+			if (found) {
+				break;
+			}
+		}
+		this.graphCanvas.setGraph(acc1[m_select], acc2[m_select], m_select_offset,
+				this.graphCanvas.getProcessFrequency());
+		this.graphCanvas.forceAddEvents();
+	}
 }

--- a/moa/src/main/java/moa/gui/TaskTextViewerPanel.java
+++ b/moa/src/main/java/moa/gui/TaskTextViewerPanel.java
@@ -16,7 +16,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ *    
  */
 package moa.gui;
 
@@ -74,7 +74,7 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
 
     private JTable previewTable;
 
-	private JTextArea errorTextField;
+    private JTextArea errorTextField;
 
     private JScrollPane scrollPaneTable;
 
@@ -114,47 +114,47 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
 
     public TaskTextViewerPanel(PreviewPanel.TypePanel typePanel, CDTaskManagerPanel taskManagerPanel) {
         this.typePanel = typePanel;
-		this.taskManagerPanel = taskManagerPanel;
-		topWrapper = new javax.swing.JPanel();
+        this.taskManagerPanel = taskManagerPanel;
+        topWrapper = new javax.swing.JPanel();
 
-		setLayout(new GridBagLayout());
+        setLayout(new GridBagLayout());
 
-		// mainPane contains the two main components of the text viewer panel:
-		// top component: preview table panel
-		// bottom component: interactive graph panel
-		this.jSplitPane1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
-		this.jSplitPane1.setDividerLocation(200);
+        // mainPane contains the two main components of the text viewer panel:
+        // top component: preview table panel
+        // bottom component: interactive graph panel
+        this.jSplitPane1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
+        this.jSplitPane1.setDividerLocation(200);
 
-		// topWrapper is the wrapper of the top component of mainPane
-		this.topWrapper = new JPanel();
-		this.topWrapper.setLayout(new BorderLayout());
+        // topWrapper is the wrapper of the top component of mainPane
+        this.topWrapper = new JPanel();
+        this.topWrapper.setLayout(new BorderLayout());
 
-		// previewTable displays live results in table form
-		// (or in text form, if an error occurs)
-		this.previewTableModel = new PreviewTableModel();
-		this.previewTable = new JTable(this.previewTableModel);
-		this.previewTable.setFont(new Font("Monospaced", Font.PLAIN, 12));
-		this.previewTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+        // previewTable displays live results in table form
+        // (or in text form, if an error occurs)
+        this.previewTableModel = new PreviewTableModel();
+        this.previewTable = new JTable(this.previewTableModel);
+        this.previewTable.setFont(new Font("Monospaced", Font.PLAIN, 12));
+        this.previewTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
-		this.errorTextField = new JTextArea();
-		this.errorTextField.setEditable(false);
-		this.errorTextField.setFont(new Font("Monospaced", Font.PLAIN, 12));
+        this.errorTextField = new JTextArea();
+        this.errorTextField.setEditable(false);
+        this.errorTextField.setFont(new Font("Monospaced", Font.PLAIN, 12));
 
-		// scrollPane enables scroll support for previewTable
-		this.scrollPaneTable = new JScrollPane(this.previewTable, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-		this.scrollPaneText = new JScrollPane(this.errorTextField, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-		this.scrollPaneText.setVisible(false);
+        // scrollPane enables scroll support for previewTable
+        this.scrollPaneTable = new JScrollPane(this.previewTable, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        this.scrollPaneText = new JScrollPane(this.errorTextField, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        this.scrollPaneText.setVisible(false);
 
-		this.topWrapper.add(this.scrollPaneTable, BorderLayout.CENTER);
+        this.topWrapper.add(this.scrollPaneTable, BorderLayout.CENTER);
 
         this.exportButton = new JButton("Export as .txt file...");
-		this.exportButton.setEnabled(false);
-		JPanel buttonPanel = new JPanel();
-		buttonPanel.setLayout(new GridLayout(1, 2));
-		buttonPanel.add(this.exportButton);
-		topWrapper.add(buttonPanel, BorderLayout.SOUTH);
+        this.exportButton.setEnabled(false);
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new GridLayout(1, 2));
+        buttonPanel.add(this.exportButton);
+        topWrapper.add(buttonPanel, BorderLayout.SOUTH);
         this.exportButton.addActionListener(new ActionListener() {
 
             public void actionPerformed(ActionEvent e) {
@@ -175,13 +175,13 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
 
                         String text = "";
 
-						if (scrollPaneTable.isVisible()) {
-							text = previewTableModel.toString();
-						} else {
-							text = errorTextField.getText();
-						}
+                        if (scrollPaneTable.isVisible()) {
+                            text = previewTableModel.toString();
+                        } else {
+                            text = errorTextField.getText();
+                        }
 
-						out.write(text);
+                        out.write(text);
                         out.close();
                     } catch (IOException ioe) {
                         GUIUtils.showExceptionDialog(
@@ -349,94 +349,94 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
     }
 
     /**
-	 * Updates the preview table based on the information given by preview.
-	 *
-	 * @param preview
-	 *            the new information used to update the table
-	 */
+     * Updates the preview table based on the information given by preview.
+     *
+     * @param preview
+     *            the new information used to update the table
+     */
      public void setText(Preview preview) {
- 		Point p = this.scrollPaneTable.getViewport().getViewPosition();
+         Point p = this.scrollPaneTable.getViewport().getViewPosition();
 
- 		previewTableModel.setPreview(preview);
- 		SwingUtilities.invokeLater(new Runnable() {
- 			boolean structureChanged = previewTableModel.structureChanged();
+         previewTableModel.setPreview(preview);
+         SwingUtilities.invokeLater(new Runnable() {
+             boolean structureChanged = previewTableModel.structureChanged();
 
- 			public void run() {
- 				if (!scrollPaneTable.isVisible()) {
- 					topWrapper.remove(scrollPaneText);
- 					scrollPaneText.setVisible(false);
- 					topWrapper.add(scrollPaneTable, BorderLayout.CENTER);
- 					scrollPaneTable.setVisible(true);
- 					topWrapper.validate();
- 				}
+             public void run() {
+                 if (!scrollPaneTable.isVisible()) {
+                     topWrapper.remove(scrollPaneText);
+                     scrollPaneText.setVisible(false);
+                     topWrapper.add(scrollPaneTable, BorderLayout.CENTER);
+                     scrollPaneTable.setVisible(true);
+                     topWrapper.validate();
+                 }
 
- 				if (structureChanged) {
- 					previewTableModel.fireTableStructureChanged();
- 					rescaleTableColumns();
- 				} else {
- 					previewTableModel.fireTableDataChanged();
- 				}
- 				previewTable.repaint();
- 			}
- 		});
+                 if (structureChanged) {
+                     previewTableModel.fireTableStructureChanged();
+                     rescaleTableColumns();
+                 } else {
+                     previewTableModel.fireTableDataChanged();
+                 }
+                 previewTable.repaint();
+             }
+         });
 
- 		this.scrollPaneTable.getViewport().setViewPosition(p);
- 		this.exportButton.setEnabled(preview != null);
- 	}
+         this.scrollPaneTable.getViewport().setViewPosition(p);
+         this.exportButton.setEnabled(preview != null);
+     }
 
     /**
-	 * Displays the error message.
-	 * @param failedTaskReport error message
-	 */
-	public void setErrorText(FailedTaskReport failedTaskReport) {
-		Point p = this.scrollPaneText.getViewport().getViewPosition();
+     * Displays the error message.
+     * @param failedTaskReport error message
+     */
+    public void setErrorText(FailedTaskReport failedTaskReport) {
+        Point p = this.scrollPaneText.getViewport().getViewPosition();
 
-		final String failedTaskReportString = failedTaskReport == null ?
-				"Failed Task Report is null" : failedTaskReport.toString();
+        final String failedTaskReportString = failedTaskReport == null ?
+                "Failed Task Report is null" : failedTaskReport.toString();
 
-		SwingUtilities.invokeLater(
-			new Runnable(){
-				public void run(){
-					if(!scrollPaneText.isVisible())
-					{
-						topWrapper.remove(scrollPaneTable);
-						scrollPaneTable.setVisible(false);
-						topWrapper.add(scrollPaneText, BorderLayout.CENTER);
-						scrollPaneText.setVisible(true);
-						topWrapper.validate();
-					}
-					errorTextField.setText(failedTaskReportString);
-					errorTextField.repaint();
-				}
-			}
-		);
+        SwingUtilities.invokeLater(
+            new Runnable(){
+                public void run(){
+                    if(!scrollPaneText.isVisible())
+                    {
+                        topWrapper.remove(scrollPaneTable);
+                        scrollPaneTable.setVisible(false);
+                        topWrapper.add(scrollPaneText, BorderLayout.CENTER);
+                        scrollPaneText.setVisible(true);
+                        topWrapper.validate();
+                    }
+                    errorTextField.setText(failedTaskReportString);
+                    errorTextField.repaint();
+                }
+            }
+        );
 
-		this.scrollPaneText.getViewport().setViewPosition(p);
-		this.exportButton.setEnabled(failedTaskReport != null);
-	}
+        this.scrollPaneText.getViewport().setViewPosition(p);
+        this.exportButton.setEnabled(failedTaskReport != null);
+    }
 
-	private void rescaleTableColumns() {
-		// iterate over all columns to resize them individually
-		TableColumnModel columnModel = previewTable.getColumnModel();
-		for (int columnIdx = 0; columnIdx < columnModel.getColumnCount(); ++columnIdx) {
-			// get the current column
-			TableColumn column = columnModel.getColumn(columnIdx);
-			// get the renderer for the column header to calculate the preferred
-			// with for the header
-			TableCellRenderer renderer = column.getHeaderRenderer();
-			// check if the renderer is null
-			if (renderer == null) {
-				// if it is null use the default renderer for header
-				renderer = previewTable.getTableHeader().getDefaultRenderer();
-			}
-			// create a cell to calculate its preferred size
-			Component comp = renderer.getTableCellRendererComponent(previewTable, column.getHeaderValue(), false, false,
-					0, columnIdx);
-			int width = comp.getPreferredSize().width;
-			// set the maximum width which was calculated
-			column.setPreferredWidth(width);
-		}
-	}
+    private void rescaleTableColumns() {
+        // iterate over all columns to resize them individually
+        TableColumnModel columnModel = previewTable.getColumnModel();
+        for (int columnIdx = 0; columnIdx < columnModel.getColumnCount(); ++columnIdx) {
+            // get the current column
+            TableColumn column = columnModel.getColumn(columnIdx);
+            // get the renderer for the column header to calculate the preferred
+            // with for the header
+            TableCellRenderer renderer = column.getHeaderRenderer();
+            // check if the renderer is null
+            if (renderer == null) {
+                // if it is null use the default renderer for header
+                renderer = previewTable.getTableHeader().getDefaultRenderer();
+            }
+            // create a cell to calculate its preferred size
+            Component comp = renderer.getTableCellRendererComponent(previewTable, column.getHeaderValue(), false, false,
+                    0, columnIdx);
+            int width = comp.getPreferredSize().width;
+            // set the maximum width which was calculated
+            column.setPreferredWidth(width);
+        }
+    }
 
     protected MeasureCollection[] acc1 = new MeasureCollection[1];
 
@@ -591,105 +591,105 @@ public class TaskTextViewerPanel extends JPanel implements ActionListener {
         // TODO add your handling code here:
     }//GEN-LAST:event_buttonRunActionPerformed
 
-	// Variables declaration - do not modify//GEN-BEGIN:variables
-	private javax.swing.JButton buttonRun;
+    // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JButton buttonRun;
 
-	private javax.swing.JButton buttonScreenshot;
+    private javax.swing.JButton buttonScreenshot;
 
-	private javax.swing.JButton buttonStop;
+    private javax.swing.JButton buttonStop;
 
-	private javax.swing.JButton buttonZoomInX;
+    private javax.swing.JButton buttonZoomInX;
 
-	private javax.swing.JButton buttonZoomInY;
+    private javax.swing.JButton buttonZoomInY;
 
-	private javax.swing.JButton buttonZoomOutX;
+    private javax.swing.JButton buttonZoomOutX;
 
-	private javax.swing.JButton buttonZoomOutY;
+    private javax.swing.JButton buttonZoomOutY;
 
-	private javax.swing.JCheckBox checkboxDrawClustering;
+    private javax.swing.JCheckBox checkboxDrawClustering;
 
-	private javax.swing.JCheckBox checkboxDrawGT;
+    private javax.swing.JCheckBox checkboxDrawGT;
 
-	private javax.swing.JCheckBox checkboxDrawMicro;
+    private javax.swing.JCheckBox checkboxDrawMicro;
 
-	private javax.swing.JCheckBox checkboxDrawPoints;
+    private javax.swing.JCheckBox checkboxDrawPoints;
 
-	private moa.gui.clustertab.ClusteringVisualEvalPanel clusteringVisualEvalPanel1;
+    private moa.gui.clustertab.ClusteringVisualEvalPanel clusteringVisualEvalPanel1;
 
-	private javax.swing.JComboBox comboX;
+    private javax.swing.JComboBox comboX;
 
-	private javax.swing.JComboBox comboY;
+    private javax.swing.JComboBox comboY;
 
-	private moa.gui.visualization.GraphCanvas graphCanvas;
+    private moa.gui.visualization.GraphCanvas graphCanvas;
 
-	private javax.swing.JPanel graphPanel;
+    private javax.swing.JPanel graphPanel;
 
-	private javax.swing.JPanel graphPanelControlBottom;
+    private javax.swing.JPanel graphPanelControlBottom;
 
-	private javax.swing.JPanel graphPanelControlTop;
+    private javax.swing.JPanel graphPanelControlTop;
 
-	private javax.swing.JScrollPane graphScrollPanel;
+    private javax.swing.JScrollPane graphScrollPanel;
 
-	private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel1;
 
-	private javax.swing.JLabel labelEvents;
+    private javax.swing.JLabel labelEvents;
 
-	private javax.swing.JLabel labelNumPause;
+    private javax.swing.JLabel labelNumPause;
 
-	private javax.swing.JLabel labelX;
+    private javax.swing.JLabel labelX;
 
-	private javax.swing.JLabel labelY;
+    private javax.swing.JLabel labelY;
 
-	private javax.swing.JLabel label_processed_points;
+    private javax.swing.JLabel label_processed_points;
 
-	private javax.swing.JLabel label_processed_points_value;
+    private javax.swing.JLabel label_processed_points_value;
 
-	private javax.swing.JTextField numPauseAfterPoints;
+    private javax.swing.JTextField numPauseAfterPoints;
 
-	private javax.swing.JPanel panelControl;
+    private javax.swing.JPanel panelControl;
 
-	private javax.swing.JPanel panelEvalOutput;
+    private javax.swing.JPanel panelEvalOutput;
 
-	private javax.swing.JPanel panelVisualWrapper;
+    private javax.swing.JPanel panelVisualWrapper;
 
-	private javax.swing.JScrollPane scrollPane0;
+    private javax.swing.JScrollPane scrollPane0;
 
-	private javax.swing.JScrollPane scrollPane1;
+    private javax.swing.JScrollPane scrollPane1;
 
-	private javax.swing.JSlider speedSlider;
+    private javax.swing.JSlider speedSlider;
 
-	private javax.swing.JSplitPane splitVisual;
+    private javax.swing.JSplitPane splitVisual;
 
-	private moa.gui.visualization.StreamPanel streamPanel0;
+    private moa.gui.visualization.StreamPanel streamPanel0;
 
-	private moa.gui.visualization.StreamPanel streamPanel1;
+    private moa.gui.visualization.StreamPanel streamPanel1;
 
-	@Override
-	public void actionPerformed(ActionEvent e) {
-		// reacte on graph selection and find out which measure was selected
-		int selected = Integer.parseInt(e.getActionCommand());
-		int counter = selected;
-		int m_select = 0;
-		int m_select_offset = 0;
-		boolean found = false;
-		for (int i = 0; i < acc1.length; i++) {
-			for (int j = 0; j < acc1[i].getNumMeasures(); j++) {
-				if (acc1[i].isEnabled(j)) {
-					counter--;
-					if (counter < 0) {
-						m_select = i;
-						m_select_offset = j;
-						found = true;
-						break;
-					}
-				}
-			}
-			if (found) {
-				break;
-			}
-		}
-		this.graphCanvas.setGraph(acc1[m_select], acc2[m_select], m_select_offset,
-				this.graphCanvas.getProcessFrequency());
-		this.graphCanvas.forceAddEvents();
-	}
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // reacte on graph selection and find out which measure was selected
+        int selected = Integer.parseInt(e.getActionCommand());
+        int counter = selected;
+        int m_select = 0;
+        int m_select_offset = 0;
+        boolean found = false;
+        for (int i = 0; i < acc1.length; i++) {
+            for (int j = 0; j < acc1[i].getNumMeasures(); j++) {
+                if (acc1[i].isEnabled(j)) {
+                    counter--;
+                    if (counter < 0) {
+                        m_select = i;
+                        m_select_offset = j;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (found) {
+                break;
+            }
+        }
+        this.graphCanvas.setGraph(acc1[m_select], acc2[m_select], m_select_offset,
+                this.graphCanvas.getProcessFrequency());
+        this.graphCanvas.forceAddEvents();
+    }
 }

--- a/moa/src/main/java/moa/gui/active/ALPreviewPanel.java
+++ b/moa/src/main/java/moa/gui/active/ALPreviewPanel.java
@@ -144,9 +144,9 @@ public class ALPreviewPanel extends JPanel implements ResultPreviewListener {
      */
     private void setLatestPreview() {
 
-    	
-    	if(this.previewedThread != null && this.previewedThread.failed())
+    	if(this.previewedThread != null && this.previewedThread.isFailed())
     	{
+    		// failed task
     		FailedTaskReport failedTaskReport = (FailedTaskReport) this.previewedThread.getFinalResult();
     		this.textViewerPanel.setErrorText(failedTaskReport);
     		this.textViewerPanel.setGraph(null, null);
@@ -155,8 +155,7 @@ public class ALPreviewPanel extends JPanel implements ResultPreviewListener {
     	{
         	Preview preview = null;
     		if ((this.previewedThread != null) && this.previewedThread.isComplete()) {
-    			// cancelled, completed or failed task
-    			// TODO if the task is failed, the finalResult is a FailedTaskReport, which is not a Preview
+    			// cancelled or completed task
     			preview = (Preview) this.previewedThread.getFinalResult();
     			this.previewLabel.setText("Final result");
     			disableRefresh();

--- a/moa/src/main/java/moa/tasks/TaskThread.java
+++ b/moa/src/main/java/moa/tasks/TaskThread.java
@@ -172,9 +172,12 @@ public class TaskThread extends Thread {
                 || (this.currentStatus == Status.COMPLETED) || (this.currentStatus == Status.FAILED));
     }
 
-	public boolean failed()
-	{
+	public boolean isFailed() {
 		return currentStatus == Status.FAILED;
+	}
+	
+	public boolean isCancelled() {
+		return currentStatus == Status.CANCELLED;
 	}
 
     public Object getFinalResult() {

--- a/moa/src/main/java/moa/tasks/TaskThread.java
+++ b/moa/src/main/java/moa/tasks/TaskThread.java
@@ -172,6 +172,11 @@ public class TaskThread extends Thread {
                 || (this.currentStatus == Status.COMPLETED) || (this.currentStatus == Status.FAILED));
     }
 
+	public boolean failed()
+	{
+		return currentStatus == Status.FAILED;
+	}
+
     public Object getFinalResult() {
         return this.finalResult;
     }

--- a/moa/src/main/java/moa/tasks/meta/ALMultiParamTask.java
+++ b/moa/src/main/java/moa/tasks/meta/ALMultiParamTask.java
@@ -322,7 +322,7 @@ public class ALMultiParamTask extends ALMainTask {
 				allThreadsCompleted &= currentTaskThread.isComplete();
 				
 				// request cancel if subtask failed or was cancelled
-				if(currentTaskThread.failed() || currentTaskThread.cancelled())
+				if(currentTaskThread.isFailed() || currentTaskThread.isCancelled())
 				{
 					monitor.requestCancel();
 				}

--- a/moa/src/main/java/moa/tasks/meta/ALPartitionEvaluationTask.java
+++ b/moa/src/main/java/moa/tasks/meta/ALPartitionEvaluationTask.java
@@ -178,7 +178,7 @@ public class ALPartitionEvaluationTask extends ALMainTask {
 				allThreadsCompleted &= currentTaskThread.isComplete();
 
 				// request cancel if subtask failed or was cancelled
-				if(currentTaskThread.failed() || currentTaskThread.cancelled())
+				if(currentTaskThread.isFailed() || currentTaskThread.isCancelled())
 				{
 					monitor.requestCancel();
 				}

--- a/moa/src/main/java/moa/tasks/meta/ALTaskThread.java
+++ b/moa/src/main/java/moa/tasks/meta/ALTaskThread.java
@@ -80,7 +80,7 @@ public class ALTaskThread extends TaskThread {
 		
         super.cancelTask();
         
-        if(!failed())
+        if(!isFailed())
         	this.finalResult = getLatestResultPreview();
         
 
@@ -93,18 +93,6 @@ public class ALTaskThread extends TaskThread {
         	}
         }
     }
-	
-	public boolean failed()
-	{
-		return currentStatus == Status.FAILED;
-	}
-	
-	public boolean cancelled()
-	{
-		return currentStatus == Status.CANCELLED;
-	}
-	
-
 
     @Override
     public void run() {


### PR DESCRIPTION
The results of a running task have previously been shown in a raw text box. In order to support visual clarity, this text box has now been replaced by a table, so that the development of each measurement can easily be analyzed.

![result_table](https://user-images.githubusercontent.com/5707898/42898306-16bfa4e8-8ac3-11e8-81c5-5ddc3b56cbc4.png)

Changes have been performed similarly to the implementation for the Active Learning tab introduced in #125.