### PR TITLE
fixed single quote char support

### DIFF
--- a/moa/src/main/java/com/yahoo/labs/samoa/instances/ArffLoader.java
+++ b/moa/src/main/java/com/yahoo/labs/samoa/instances/ArffLoader.java
@@ -158,7 +158,7 @@ public class ArffLoader {
                         numAttribute++;
 
                     } else if (streamTokenizer.sval != null && (streamTokenizer.ttype == StreamTokenizer.TT_WORD
-                            || streamTokenizer.ttype == 34)) {
+                            || streamTokenizer.ttype == 34 || streamTokenizer.ttype == 39)) {
                         //System.out.println(streamTokenizer.sval + "Str");
                         boolean isNumeric = this.instanceInformation.attribute(numAttribute).isNumeric();
                         double value;


### PR DESCRIPTION
StreamTokenizer class gives suport to quotted string with single quote char, but ArffLoader was allowing only tokens with ttype 34 ( " ) and ignoring any token with ttype 39 ( ' ). This commit fix that.