### PR TITLE
Fixes for a few bugs in the multi-label performance estimator

### DIFF
--- a/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
@@ -53,9 +53,6 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
     /** running number of examples */
     int sumExamples = 0;
 
-    /** preset threshold */
-    private double t = 0.5;
-
     @Override
     public void reset() {
         sumAccuracy = 0.0;
@@ -75,21 +72,7 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
         int sumOnesTrue=0;
         int sumOnesPred=0;
 
-
         MultiLabelInstance x = (MultiLabelInstance) example.getData();
-
-        for (int j = 0; j < y.numOutputAttributes(); j++) {
-            System.out.print( (int)x.classValue(j));
-        }
-        System.out.print(" ");
-
-
-        for (int j = 0; j < y.numOutputAttributes(); j++) {
-            System.out.print( (y.getVote(j,1) > t) ? 1 : 0);
-        }
-        System.out.print("\n");
-
-
 
         if (L == 0) {
             L = x.numberOutputTargets();
@@ -105,7 +88,7 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
             sumExamples++;
             int correct = 0;
             for (int j = 0; j < y.numOutputAttributes(); j++) {
-                int yp = (y.getVote(j,1) > t) ? 1 : 0;
+                int yp = (y.getVote(j,1) > y.getVote(j, 0)) ? 1 : 0;
 
                 int y_true = (int)x.valueOutputAttribute(j);
                 if (y_true == yp)
@@ -125,15 +108,11 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
 
             }
 
-            double tmp=0;
-
             //Accuracy by instance(Jaccard Index)
             if(sumReunion>0){
-                tmp=(double)sumInterse/sumReunion;
                 sumAccuracy2 += (double)sumInterse/sumReunion;
             }
             else{
-                tmp=1;
                 sumAccuracy2+=0.0;
             }
 

--- a/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
@@ -85,7 +85,7 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
 
 
         for (int j = 0; j < y.numOutputAttributes(); j++) {
-            System.out.print( (y.getVote(j,0) > t) ? 1 : 0);
+            System.out.print( (y.getVote(j,1) > t) ? 1 : 0);
         }
         System.out.print("\n");
 

--- a/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
@@ -106,7 +106,6 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
             int correct = 0;
             for (int j = 0; j < y.numOutputAttributes(); j++) {
                 int yp = (y.getVote(j,1) > t) ? 1 : 0;
-                correct += ((int)x.classValue(j) == yp) ? 1 : 0;
 
                 int y_true = (int)x.valueOutputAttribute(j);
                 if (y_true == yp)

--- a/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/BasicMultiLabelPerformanceEvaluator.java
@@ -105,7 +105,7 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
             sumExamples++;
             int correct = 0;
             for (int j = 0; j < y.numOutputAttributes(); j++) {
-                int yp = (y.getVote(j,0) > t) ? 1 : 0;
+                int yp = (y.getVote(j,1) > t) ? 1 : 0;
                 correct += ((int)x.classValue(j) == yp) ? 1 : 0;
 
                 int y_true = (int)x.valueOutputAttribute(j);
@@ -167,8 +167,8 @@ public class BasicMultiLabelPerformanceEvaluator extends AbstractMOAObject imple
         // gather measurements
         Measurement m[] = new Measurement[]{
                 new Measurement("Exact Match", sumAccuracy/sumExamples),
+                new Measurement("Accuracy", (double) sumAccuracy2/sumExamples),
                 new Measurement("Hamming Score", sumHamming/sumExamples),
-                new Measurement("Accuracy", (double) sumAccuracy/sumExamples),
                 new Measurement("Precision",((double) sumPrecision)/sumExamples),
                 new Measurement("Recall",(double) sumRecall/sumExamples),
                 new Measurement("F-Measure", (double) sumFmeasure/sumExamples),


### PR DESCRIPTION
Was evaluating the inverse of the predictions made by the model. In the case of BasicMultiLabelLearner, this was cancelled out by another bug fixed in #156.

The number of correct predictions was also being incremented twice for each correct prediction.