### PR TITLE
Fixes EvaluateModel and LearnModel after the introduction of the new preview table

### DIFF
--- a/moa/.classpath
+++ b/moa/.classpath
@@ -13,17 +13,20 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-10">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/moa/.settings/org.eclipse.core.resources.prefs
+++ b/moa/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,6 @@
 eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
 encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
 encoding//src/test/resources=UTF-8
 encoding/<project>=UTF-8

--- a/moa/.settings/org.eclipse.jdt.core.prefs
+++ b/moa/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=10
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=10
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=10

--- a/moa/src/main/java/moa/gui/PreviewPanel.java
+++ b/moa/src/main/java/moa/gui/PreviewPanel.java
@@ -163,20 +163,27 @@ public class PreviewPanel extends JPanel implements ResultPreviewListener {
         	Preview preview = null;
     		if ((this.previewedThread != null) && this.previewedThread.isComplete()) {
     			// cancelled or completed task
-    			preview = (Preview) this.previewedThread.getFinalResult();
-    			this.previewLabel.setText("Final result");
+    			Object previewObject = this.previewedThread.getFinalResult();
+    			if(Preview.class.isInstance(previewObject))
+    			{
+        			preview = (Preview) this.previewedThread.getFinalResult();
+        			this.previewLabel.setText("Final result");
+    			}
     			disableRefresh();
     		} else if (this.previewedThread != null){
     			// running task
-    			preview = (Preview) this.previewedThread.getLatestResultPreview();
-    			double grabTime = this.previewedThread.getLatestPreviewGrabTimeSeconds();
-    			String grabString = " (" + StringUtils.secondsToDHMSString(grabTime) + ")";
-    			if (preview == null) {
-    				this.previewLabel.setText("No preview available" + grabString);
-    			} else {
-    				this.previewLabel.setText("Preview" + grabString);
+    			Object previewObject = this.previewedThread.getLatestResultPreview();
+    			if(Preview.class.isInstance(previewObject))
+    			{
+        			preview = (Preview) this.previewedThread.getLatestResultPreview();
+        			double grabTime = this.previewedThread.getLatestPreviewGrabTimeSeconds();
+        			String grabString = " (" + StringUtils.secondsToDHMSString(grabTime) + ")";
+        			if (preview != null) {
+        				this.previewLabel.setText("Preview" + grabString);
+        			}
     			}
-    		} else {
+    		} 
+    		if (preview == null){
     			// no thread
     			this.previewLabel.setText("No preview available");
     			preview = null;

--- a/weka-package/.classpath
+++ b/weka-package/.classpath
@@ -10,9 +10,10 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/weka-package/.settings/org.eclipse.jdt.core.prefs
+++ b/weka-package/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,6 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
Both tasks mentioned in the title were not working after the introduction of the preview table to the classification task. They used an older method of returning results, which were not compatible with the new preview table.
Both tasks have been updated to be compatible with the preview table.