### PR TITLE
Add MOA Docker images, fix #138 & configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: java
 
 jdk:
-- oraclejdk7
+  - oraclejdk11
+
+install: true
+
+deploy:
+  provider: script
+  script: mvn clean package
 
 notifications:
-  email:
-  on_success: never
-  on_failure: change
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,5 @@ language: java
 
 jdk: oraclejdk11
 
-install: true
-
-script: true
-
-deploy:
-  provider: script
-  script: mvn clean test
-
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: java
 
-jdk:
-  - oraclejdk11
+jdk: oraclejdk11
 
 install: true
 
+script: true
+
 deploy:
   provider: script
-  script: mvn clean package
+  script: mvn clean test
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # MOA (Massive Online Analysis)
+[![Build Status](https://travis-ci.org/Waikato/moa.svg?branch=master)](https://travis-ci.org/Waikato/moa)
+[![Maven Central](https://img.shields.io/maven-central/v/nz.ac.waikato.cms.moa/moa-pom.svg)](https://mvnrepository.com/artifact/nz.ac.waikato.cms)
+[![DockerHub](https://img.shields.io/badge/docker-available-blue.svg?logo=docker)](https://hub.docker.com/r/waikato/moa)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 ![MOA][logo]
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,8 @@
+build-latest:
+	    docker build -t waikato/moa:latest -f moa-gui.Dockerfile .
+build-devel:
+	    docker build -t waikato/moa:devel -f devel-gui.Dockerfile .
+push-latest:
+	    docker push waikato/moa:latest
+push-devel:
+	    docker push waikato/moa:latest

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,4 +5,4 @@ build-devel:
 push-latest:
 	    docker push waikato/moa:latest
 push-devel:
-	    docker push waikato/moa:latest
+	    docker push waikato/moa:devel

--- a/docker/devel-gui.Dockerfile
+++ b/docker/devel-gui.Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:18.04
+
+RUN mkdir /app
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        wget \
+        git \
+        ca-certificates \
+        default-jre \
+        openjdk-8-jdk \
+        maven \
+        unzip \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+
+RUN git clone https://github.com/garawalid/moa.git
+
+RUN cd moa && \
+    export JAVA_HOME="/usr" && \
+    mvn clean install -DskipTests=true && \
+    mvn -f release.xml package -DskipTests=true
+
+RUN cd /app/moa/target/ && ls -1 | egrep 'moa-.*-SNAPSHOT-bin.zip' | xargs cp -t /app
+
+RUN rm -rf moa
+
+RUN ls -1 | egrep 'moa-.*-SNAPSHOT-bin.zip' | xargs unzip
+
+RUN rm *.zip
+
+RUN mv moa-* moa
+
+CMD moa/bin/moa.sh

--- a/docker/devel-gui.Dockerfile
+++ b/docker/devel-gui.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 
-RUN git clone https://github.com/garawalid/moa.git
+RUN git clone https://github.com/Waikato/moa.git
 
 RUN cd moa && \
     export JAVA_HOME="/usr" && \

--- a/docker/moa-gui.Dockerfile
+++ b/docker/moa-gui.Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:18.04
+
+RUN mkdir /app
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        wget \
+        unzip \
+        curl \
+        ca-certificates \
+        default-jre \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN url=$(curl --silent "https://api.github.com/repos/Waikato/moa/releases/latest"  | grep -Po '"browser_download_url": "\K.*-bin\.zip(?=")') && \
+    wget $url && \
+    file=$(echo $url | grep -Po '/[0-9.]{1,}\/\K.*[^-bin.zip]') && \
+    unzip $file-bin.zip && mv $file moa && \
+    rm $file-bin.zip
+
+CMD moa/bin/moa.sh

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,18 @@
+## Build MOA Docker images:
+
+Build latest image 
+```bash
+$ make build-latest
+```
+Build devel image 
+```bash
+$ make build-devel
+```
+Push latest image 
+```bash
+$ make push-latest
+```
+Push devel image 
+```bash
+$ make push-devel
+```

--- a/moa/src/main/java/moa/gui/outliertab/OutlierAlgoPanel.java
+++ b/moa/src/main/java/moa/gui/outliertab/OutlierAlgoPanel.java
@@ -52,7 +52,7 @@ public class OutlierAlgoPanel extends javax.swing.JPanel implements ActionListen
                "Algorithm to use.", MyBaseOutlierDetector.class, "MCOD.MCOD");
     
     private ClassOption algorithmOption1 = new ClassOption("Algorithm1", 'a',
-               "Algorithm to use.", MyBaseOutlierDetector.class, "Angiulli.ExactSTORM");
+               "Algorithm to use.", MyBaseOutlierDetector.class, "Angiulli.ExactSTORM","None");
    
     public OutlierAlgoPanel() {
         initComponents();

--- a/pom.xml
+++ b/pom.xml
@@ -263,10 +263,11 @@
           </executions>
         </plugin>
 
+        <!-- generate documentation -->
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
+          <groupId>com.github.fracpete</groupId>
           <artifactId>latex-maven-plugin</artifactId>
-          <version>1.1</version>
+          <version>1.4.1</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -275,6 +276,9 @@
               </goals>
             </execution>
           </executions>
+          <configuration>
+            <forceBuild>true</forceBuild>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Changes proposed in this pull request:
- MOA Docker images with GUI. 

|Tags| Description |
|:---:|:---:|
|latest	| MOA GUI image|
|devel|MOA GUI image that tracks Github repository |

- Docker organization for MOA [waikato/moa](https://hub.docker.com/r/waikato/moa)
- [Tutorial: Getting Started with MOA Docker](https://gist.github.com/garawalid/bbd731d57dd5a2ed64206fa32ba68457) to be included in the MOA website. 
- Fix issue #138 
- Fix pom.xml 
- Configure Travis CI: Run tests for each commit or PR.  

MOA Docker images have been tested with :
+ Windows 10
+ Ubuntu 16.04.4 LTS
+ MacOS Mojave 10.14.3