### PR TITLE
Experimenter couldn't use Imbalanced Streams with custom parameters

### DIFF
--- a/moa/src/main/java/moa/gui/experimentertab/TaskManagerTabPanel.java
+++ b/moa/src/main/java/moa/gui/experimentertab/TaskManagerTabPanel.java
@@ -913,16 +913,17 @@ public class TaskManagerTabPanel extends JPanel {
                     f = new File(sfile);
                     f.mkdir();
                 }
+
                 String task = " -l ";
+
                 if (alg.split(" ") != null) {
-                    task += "(" + alg + ") -s (" + stream + ")" + " -d (" + dir + File.separator
-                            + streamFile + File.separator + algFile + ".txt" + ")";
+                    task += "(" + alg + ")";
                 } else {
-                    task += alg + " -s (" + stream + ")" + " -d (" + dir + File.separator
-                            + streamFile + File.separator + algFile + ".txt" + ")";
+                    task += alg;
                 }
-//                String task = FilenameUtils.separatorsToSystem(" -l (" + alg + ") -s (" + stream + ") " + " -d " + "(" + dir + "\\\\"
-//                        + streamFile.split(" ")[0] + "\\\\" + algFile + ".txt" + ")");
+
+                task += " -s (" + stream + ")" + " -d (" + dir + File.separator
+                        + streamFile + File.separator + algFile + ".txt" + ")";
                 auxTask.getOptions().setViaCLIString(task);
 
                 try {

--- a/moa/src/main/java/moa/gui/experimentertab/TaskManagerTabPanel.java
+++ b/moa/src/main/java/moa/gui/experimentertab/TaskManagerTabPanel.java
@@ -916,10 +916,10 @@ public class TaskManagerTabPanel extends JPanel {
                 String task = " -l ";
                 if (alg.split(" ") != null) {
                     task += "(" + alg + ") -s (" + stream + ")" + " -d (" + dir + File.separator
-                            + streamFile.split(" ")[0] + File.separator + algFile + ".txt" + ")";
+                            + streamFile + File.separator + algFile + ".txt" + ")";
                 } else {
                     task += alg + " -s (" + stream + ")" + " -d (" + dir + File.separator
-                            + streamFile.split(" ")[0] + File.separator + algFile + ".txt" + ")";
+                            + streamFile + File.separator + algFile + ".txt" + ")";
                 }
 //                String task = FilenameUtils.separatorsToSystem(" -l (" + alg + ") -s (" + stream + ") " + " -d " + "(" + dir + "\\\\"
 //                        + streamFile.split(" ")[0] + "\\\\" + algFile + ".txt" + ")");


### PR DESCRIPTION
When using experimenter, it uses a part of the task string to create folders were the results will be inserted. The problem is that the way the string was obtained before running the task didn't matched the created folder.