### PR TITLE
fix method to deal with NaN values

### DIFF
--- a/moa/src/main/java/moa/evaluation/FadingFactorClassificationPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/FadingFactorClassificationPerformanceEvaluator.java
@@ -66,8 +66,10 @@ public class FadingFactorClassificationPerformanceEvaluator extends BasicClassif
 
         @Override
         public void add(double value) {
+          if (!Double.isNaN(value)) {
             estimation = alpha * estimation + value;
             b = alpha * b + 1.0;
+          }
         }
 
         @Override


### PR DESCRIPTION
Please, see https://github.com/Waikato/moa/issues/181 for details about the bug.

This PR applies the same solution found in BasicClassificationPerformanceEvaluator.BasicEstimator.add(double) to  
FadingFactorClassificationPerformanceEvaluator.FadingFactorEstimator.add(double) 

close https://github.com/Waikato/moa/issues/181