### PR TITLE
Updates to ARF and ARFReg default parameters

### DIFF
--- a/moa/src/main/java/moa/classifiers/meta/AdaptiveRandomForest.java
+++ b/moa/src/main/java/moa/classifiers/meta/AdaptiveRandomForest.java
@@ -98,16 +98,16 @@ public class AdaptiveRandomForest extends AbstractClassifier implements MultiCla
             "ARFHoeffdingTree -e 2000000 -g 50 -c 0.01");
 
     public IntOption ensembleSizeOption = new IntOption("ensembleSize", 's',
-        "The number of trees.", 10, 1, Integer.MAX_VALUE);
+        "The number of trees.", 100, 1, Integer.MAX_VALUE);
     
     public MultiChoiceOption mFeaturesModeOption = new MultiChoiceOption("mFeaturesMode", 'o', 
         "Defines how m, defined by mFeaturesPerTreeSize, is interpreted. M represents the total number of features.",
         new String[]{"Specified m (integer value)", "sqrt(M)+1", "M-(sqrt(M)+1)",
             "Percentage (M * (m / 100))"},
-        new String[]{"SpecifiedM", "SqrtM1", "MSqrtM1", "Percentage"}, 1);
+        new String[]{"SpecifiedM", "SqrtM1", "MSqrtM1", "Percentage"}, 3);
     
     public IntOption mFeaturesPerTreeSizeOption = new IntOption("mFeaturesPerTreeSize", 'm',
-        "Number of features allowed considered for each split. Negative values corresponds to M - m", 2, Integer.MIN_VALUE, Integer.MAX_VALUE);
+        "Number of features allowed considered for each split. Negative values corresponds to M - m", 60, Integer.MIN_VALUE, Integer.MAX_VALUE);
     
     public FloatOption lambdaOption = new FloatOption("lambda", 'a',
         "The lambda parameter for bagging.", 6.0, 1.0, Float.MAX_VALUE);
@@ -116,10 +116,10 @@ public class AdaptiveRandomForest extends AbstractClassifier implements MultiCla
         "Total number of concurrent jobs used for processing (-1 = as much as possible, 0 = do not use multithreading)", 1, -1, Integer.MAX_VALUE);
     
     public ClassOption driftDetectionMethodOption = new ClassOption("driftDetectionMethod", 'x',
-        "Change detector for drifts and its parameters", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-5");
+        "Change detector for drifts and its parameters", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-3");
 
     public ClassOption warningDetectionMethodOption = new ClassOption("warningDetectionMethod", 'p',
-        "Change detector for warnings (start training bkg learner)", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-4");
+        "Change detector for warnings (start training bkg learner)", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-2");
     
     public FlagOption disableWeightedVote = new FlagOption("disableWeightedVote", 'w', 
             "Should use weighted voting?");
@@ -388,7 +388,7 @@ public class AdaptiveRandomForest extends AbstractClassifier implements MultiCla
         }
 
         public void trainOnInstance(Instance instance, double weight, long instancesSeen) {
-            Instance weightedInstance = (Instance) instance.copy();
+            Instance weightedInstance = instance.copy();
             weightedInstance.setWeight(instance.weight() * weight);
             this.classifier.trainOnInstance(weightedInstance);
             
@@ -425,7 +425,6 @@ public class AdaptiveRandomForest extends AbstractClassifier implements MultiCla
                 }
                 
                 /*********** drift detection ***********/
-                
                 // Update the DRIFT detection method
                 this.driftDetectionMethod.input(correctlyClassifies ? 0 : 1);
                 // Check if there was a change
@@ -470,7 +469,7 @@ public class AdaptiveRandomForest extends AbstractClassifier implements MultiCla
         }
 
         @Override
-        public Integer call() throws Exception {
+        public Integer call() {
             run();
             return 0;
         }

--- a/moa/src/main/java/moa/classifiers/meta/AdaptiveRandomForestRegressor.java
+++ b/moa/src/main/java/moa/classifiers/meta/AdaptiveRandomForestRegressor.java
@@ -52,31 +52,28 @@ public class AdaptiveRandomForestRegressor extends AbstractClassifier implements
 
     public ClassOption treeLearnerOption = new ClassOption("treeLearner", 'l',
             "Random Forest Tree.", ARFFIMTDD.class,
-            "ARFFIMTDD");
+            "ARFFIMTDD -s VarianceReductionSplitCriterion -g 50 -c 0.01");
 
     public IntOption ensembleSizeOption = new IntOption("ensembleSize", 's',
-            "The number of trees.", 10, 1, Integer.MAX_VALUE);
+            "The number of trees.", 100, 1, Integer.MAX_VALUE);
 
     public MultiChoiceOption mFeaturesModeOption = new MultiChoiceOption("mFeaturesMode", 'o',
             "Defines how m, defined by mFeaturesPerTreeSize, is interpreted. M represents the total number of features.",
             new String[]{"Specified m (integer value)", "sqrt(M)+1", "M-(sqrt(M)+1)",
                     "Percentage (M * (m / 100))"},
-            new String[]{"SpecifiedM", "SqrtM1", "MSqrtM1", "Percentage"}, 1);
+            new String[]{"SpecifiedM", "SqrtM1", "MSqrtM1", "Percentage"}, 3);
 
     public IntOption mFeaturesPerTreeSizeOption = new IntOption("mFeaturesPerTreeSize", 'm',
-            "Number of features allowed considered for each split. Negative values corresponds to M - m", 2, Integer.MIN_VALUE, Integer.MAX_VALUE);
+            "Number of features allowed considered for each split. Negative values corresponds to M - m", 60, Integer.MIN_VALUE, Integer.MAX_VALUE);
 
     public FloatOption lambdaOption = new FloatOption("lambda", 'a',
             "The lambda parameter for bagging.", 6.0, 1.0, Float.MAX_VALUE);
 
     public ClassOption driftDetectionMethodOption = new ClassOption("driftDetectionMethod", 'x',
-            "Change detector for drifts and its parameters", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-5");
+            "Change detector for drifts and its parameters", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-3");
 
     public ClassOption warningDetectionMethodOption = new ClassOption("warningDetectionMethod", 'p',
-            "Change detector for warnings (start training bkg learner)", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-4");
-
-    public FlagOption disableWeightedVote = new FlagOption("disableWeightedVote", 'w',
-            "Should use weighted voting?");
+            "Change detector for warnings (start training bkg learner)", ChangeDetector.class, "ADWINChangeDetector -a 1.0E-2");
 
     public FlagOption disableDriftDetectionOption = new FlagOption("disableDriftDetection", 'u',
             "Should use drift detection? If disabled then bkg learner is also disabled");

--- a/moa/src/main/java/moa/classifiers/trees/FIMTDD.java
+++ b/moa/src/main/java/moa/classifiers/trees/FIMTDD.java
@@ -44,8 +44,12 @@ import moa.core.Measurement;
 import moa.core.SizeOf;
 import moa.core.StringUtils;
 
-/*
+/**
  * Implementation of FIMTDD, regression and model trees for data streams.
+ *
+ * <p>See details in:<br> Ikonomovska, Elena, João Gama, and Sašo Džeroski.
+ * Learning model trees from evolving data streams.
+ * Data mining and knowledge discovery 23.1 (2011): 128-168.</p>
  */
 
 public class FIMTDD extends AbstractClassifier implements Regressor {

--- a/moa/src/test/java/moa/classifiers/meta/AdaptiveRandomForestTest.java
+++ b/moa/src/test/java/moa/classifiers/meta/AdaptiveRandomForestTest.java
@@ -52,8 +52,13 @@ public class AdaptiveRandomForestTest
    */
   @Override
   protected Classifier[] getRegressionClassifierSetups() {
+    AdaptiveRandomForest ARFTest = new AdaptiveRandomForest();
+    ARFTest.ensembleSizeOption.setValue(5);
+    ARFTest.mFeaturesModeOption.setChosenIndex(0);
+    ARFTest.mFeaturesPerTreeSizeOption.setValue(2);
+
     return new Classifier[]{
-	new AdaptiveRandomForest(),
+            ARFTest,
     };
   }
   

--- a/moa/src/test/resources/moa/classifiers/meta/AdaptiveRandomForest.ref
+++ b/moa/src/test/resources/moa/classifiers/meta/AdaptiveRandomForest.ref
@@ -1,143 +1,143 @@
 --> classification-out0.arff
-moa.classifiers.meta.AdaptiveRandomForest -l (ARFHoeffdingTree -k 4 -e 2000000 -g 50 -c 0.01)
+moa.classifiers.meta.AdaptiveRandomForest -s 5 -o (Specified m (integer value)) -m 2 -x (ADWINChangeDetector -a 0.001) -p (ADWINChangeDetector -a 0.01)
 
 Index
   10000
 Votes
-  0: 330.80770429
-  1: 215.60693717
+  0: 206.45597761
+  1: 115.89625761
 Measurements
   classified instances: 9999
-  classifications correct (percent): 78.21782178
-  Kappa Statistic (percent): 53.51812686
-  Kappa Temporal Statistic (percent): 54.08937605
-  Kappa M Statistic (percent): 46.81318681
+  classifications correct (percent): 72.32723272
+  Kappa Statistic (percent): 40.82229095
+  Kappa Temporal Statistic (percent): 41.67369309
+  Kappa M Statistic (percent): 32.42979243
 Model measurements
   model training instances: 9999
 
 Index
   20000
 Votes
-  0: 406.54784576
-  1: 291.24704399
+  0: 177.44989015
+  1: 152.64161442
 Measurements
   classified instances: 19999
-  classifications correct (percent): 81.44907245
-  Kappa Statistic (percent): 61.00039371
-  Kappa Temporal Statistic (percent): 61.26944357
-  Kappa M Statistic (percent): 55.5262527
+  classifications correct (percent): 73.98869943
+  Kappa Statistic (percent): 44.9828451
+  Kappa Temporal Statistic (percent): 45.69370498
+  Kappa M Statistic (percent): 37.64085351
 Model measurements
   model training instances: 19999
 
 Index
   30000
 Votes
-  0: 164.18005814
-  1: 402.04548271
+  0: 0
+  1: 334.91116371
 Measurements
   classified instances: 29999
-  classifications correct (percent): 83.0961032
-  Kappa Statistic (percent): 64.54889831
-  Kappa Temporal Statistic (percent): 64.97202459
-  Kappa M Statistic (percent): 59.3930173
+  classifications correct (percent): 75.03583453
+  Kappa Statistic (percent): 47.2533335
+  Kappa Temporal Statistic (percent): 48.26966913
+  Kappa M Statistic (percent): 40.03042921
 Model measurements
   model training instances: 29999
 
 Index
   40000
 Votes
-  0: 104.81604605
-  1: 545.53521274
+  0: 71.65357524
+  1: 265.45485247
 Measurements
   classified instances: 39999
-  classifications correct (percent): 84.1321033
-  Kappa Statistic (percent): 66.84789141
-  Kappa Temporal Statistic (percent): 67.20066146
-  Kappa M Statistic (percent): 62.03947368
+  classifications correct (percent): 75.72439311
+  Kappa Statistic (percent): 48.87876052
+  Kappa Temporal Statistic (percent): 49.82171464
+  Kappa M Statistic (percent): 41.92583732
 Model measurements
   model training instances: 39999
 
 Index
   50000
 Votes
-  0: 510.06176841
-  1: 146.57336429
+  0: 212.11247085
+  1: 126.70430548
 Measurements
   classified instances: 49999
-  classifications correct (percent): 84.85769715
-  Kappa Statistic (percent): 68.39508967
-  Kappa Temporal Statistic (percent): 68.66048514
-  Kappa M Statistic (percent): 63.7681853
+  classifications correct (percent): 76.21952439
+  Kappa Statistic (percent): 49.93502615
+  Kappa Temporal Statistic (percent): 50.78234953
+  Kappa M Statistic (percent): 43.09915773
 Model measurements
   model training instances: 49999
 
 Index
   60000
 Votes
-  0: 143.78177777
-  1: 516.72256397
+  0: 12.41706613
+  1: 328.24361154
 Measurements
   classified instances: 59999
-  classifications correct (percent): 85.57475958
-  Kappa Statistic (percent): 69.98094709
-  Kappa Temporal Statistic (percent): 70.17060141
-  Kappa M Statistic (percent): 65.6574875
+  classifications correct (percent): 76.67461124
+  Kappa Statistic (percent): 51.00363674
+  Kappa Temporal Statistic (percent): 51.76632776
+  Kappa M Statistic (percent): 44.46869296
 Model measurements
   model training instances: 59999
 
 Index
   70000
 Votes
-  0: 96.13210555
-  1: 642.71559227
+  0: 132.32777864
+  1: 209.75282251
 Measurements
   classified instances: 69999
-  classifications correct (percent): 86.09265847
-  Kappa Statistic (percent): 71.12186853
-  Kappa Temporal Statistic (percent): 71.33307812
-  Kappa M Statistic (percent): 67.00447397
+  classifications correct (percent): 77.01252875
+  Kappa Statistic (percent): 51.80847458
+  Kappa Temporal Statistic (percent): 52.61639035
+  Kappa M Statistic (percent): 45.46163232
 Model measurements
   model training instances: 69999
 
 Index
   80000
 Votes
-  0: 132.15166135
-  1: 537.29295671
+  0: 101.72267738
+  1: 241.58161393
 Measurements
   classified instances: 79999
-  classifications correct (percent): 86.53358167
-  Kappa Statistic (percent): 72.05637929
-  Kappa Temporal Statistic (percent): 72.26955649
-  Kappa M Statistic (percent): 68.04781113
+  classifications correct (percent): 77.33971675
+  Kappa Statistic (percent): 52.52532245
+  Kappa Temporal Statistic (percent): 53.33728024
+  Kappa M Statistic (percent): 46.23324238
 Model measurements
   model training instances: 79999
 
 Index
   90000
 Votes
-  0: 191.58405665
-  1: 556.30425322
+  0: 115.07689707
+  1: 229.5047094
 Measurements
   classified instances: 89999
-  classifications correct (percent): 86.93985489
-  Kappa Statistic (percent): 72.91620819
-  Kappa Temporal Statistic (percent): 73.09373927
-  Kappa M Statistic (percent): 69.00316456
+  classifications correct (percent): 77.70753008
+  Kappa Statistic (percent): 53.31059019
+  Kappa Temporal Statistic (percent): 54.0734806
+  Kappa M Statistic (percent): 47.09124473
 Model measurements
   model training instances: 89999
 
 Index
   100000
 Votes
-  0: 664.14022916
-  1: 87.55028775
+  0: 177.04261024
+  1: 168.56784587
 Measurements
   classified instances: 99999
-  classifications correct (percent): 87.29387294
-  Kappa Statistic (percent): 73.67417181
-  Kappa Temporal Statistic (percent): 73.82580751
-  Kappa M Statistic (percent): 69.87814708
+  classifications correct (percent): 77.96877969
+  Kappa Statistic (percent): 53.89151466
+  Kappa Temporal Statistic (percent): 54.61643045
+  Kappa M Statistic (percent): 47.77156133
 Model measurements
   model training instances: 99999
 


### PR DESCRIPTION
Updates to ARF default parameters. The proposed configuration resembles the ARF_fast configuration defined in the original paper. 

Updates to ARFReg default parameters. The proposed configuration resembles the ARFReg-inv, but using m=60% (same as ARF). 

Updates to ARFFIMTDD. Removed the option to NOT build regression trees. 

Updates to FIMTDD. Added the reference to the original paper. 