### PR TITLE
These returns causes instance skip

### DIFF
--- a/moa/src/main/java/moa/clusterers/clustream/Clustream.java
+++ b/moa/src/main/java/moa/clusterers/clustream/Clustream.java
@@ -103,7 +103,6 @@ public class Clustream extends AbstractClusterer{
 
 			buffer.clear();
 			initialized = true;
-			return;
 		}
 
 

--- a/moa/src/main/java/moa/clusterers/clustream/WithKmeans.java
+++ b/moa/src/main/java/moa/clusterers/clustream/WithKmeans.java
@@ -101,7 +101,6 @@ public class WithKmeans extends AbstractClusterer {
 	
 				buffer.clear();
 				initialized = true;
-				return;
 			}
 		}
 


### PR DESCRIPTION
With these returns, instances (points) with timestamp == m are being skipped in the algorithm.