### PR TITLE
Fix CICD pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: java
 
 jdk: oraclejdk11
 
+install: sudo apt-get install texlive-full
+
 notifications:
   email: false

--- a/docker/devel-gui.Dockerfile
+++ b/docker/devel-gui.Dockerfile
@@ -4,6 +4,10 @@ RUN mkdir /app
 
 WORKDIR /app
 
+# This is a workaround to bypass the tzdata prompts
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         wget \
         git \
@@ -12,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         openjdk-8-jdk \
         maven \
         unzip \
+        texlive-full \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR resolves the following points:
- Fix the build of moa in Travis CI. The pipeline was broken due to a missing package (texlive-full)
- Fix the devel Docker image.

### Fix the developement Docker image:
The build of the devel image is broken in the [waikato/moa repository](https://hub.docker.com/r/waikato/moa). It will be fixed once we merge the current PR.

How to reproduce the tests of the devel image:
```bash
$ cd docker & make build-devel
$ docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" waikato/moa:devel
```