### PR TITLE
Fix resetLearning to clear ArrayLists

### DIFF
--- a/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineAdaBoost.java
+++ b/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineAdaBoost.java
@@ -96,11 +96,11 @@ public class OnlineAdaBoost extends AbstractClassifier implements MultiClassClas
     protected Classifier baseLearner;
     protected int nEstimators;    
     protected boolean driftDetection;        
-    protected ArrayList<Classifier> ensemble = new ArrayList<Classifier>();    
-    protected ArrayList<ADWIN> adwinEnsemble = new ArrayList<ADWIN>();        
-    protected ArrayList<Double> lambdaSc = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaSw = new ArrayList<Double>();
-    protected ArrayList<Double> epsilon = new ArrayList<Double>();     
+    protected ArrayList<Classifier> ensemble;
+    protected ArrayList<ADWIN> adwinEnsemble;
+    protected ArrayList<Double> lambdaSc;
+    protected ArrayList<Double> lambdaSw;
+    protected ArrayList<Double> epsilon;     
     
     @Override
     public void resetLearningImpl() {
@@ -108,7 +108,14 @@ public class OnlineAdaBoost extends AbstractClassifier implements MultiClassClas
     	this.baseLearner = (Classifier) getPreparedClassOption(this.baseLearnerOption);
     	this.baseLearner.resetLearning();
         this.nEstimators = this.ensembleSizeOption.getValue();        
-        this.driftDetection = !this.disableDriftDetectionOption.isSet();                
+        this.driftDetection = !this.disableDriftDetectionOption.isSet();
+        this.ensemble = new ArrayList<Classifier>();
+        if (this.driftDetection) {
+            this.adwinEnsemble = new ArrayList<ADWIN>();
+        }
+        this.ambdaSc = new ArrayList<Double>();
+        this.lambdaSw = new ArrayList<Double>();
+        this.epsilon = new ArrayList<Double>();
         for (int i = 0; i < this.nEstimators; i++) {
         	this.ensemble.add(this.baseLearner.copy());         	        
         	if (this.driftDetection) {

--- a/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineAdaC2.java
+++ b/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineAdaC2.java
@@ -102,15 +102,15 @@ public class OnlineAdaC2 extends AbstractClassifier implements MultiClassClassif
     protected double costPositive;
     protected double costNegative;
     protected boolean driftDetection;        
-    protected ArrayList<Classifier> ensemble = new ArrayList<Classifier>();    
-    protected ArrayList<ADWIN> adwinEnsemble = new ArrayList<ADWIN>();
-    protected ArrayList<Double> lambdaTP = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaTN = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaFP = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaFN = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaSum = new ArrayList<Double>();
-    protected ArrayList<Double> wAcc = new ArrayList<Double>();
-    protected ArrayList<Double> wErr = new ArrayList<Double>();     
+    protected ArrayList<Classifier> ensemble;
+    protected ArrayList<ADWIN> adwinEnsemble;
+    protected ArrayList<Double> lambdaTP;
+    protected ArrayList<Double> lambdaTN;
+    protected ArrayList<Double> lambdaFP;
+    protected ArrayList<Double> lambdaFN;
+    protected ArrayList<Double> lambdaSum;
+    protected ArrayList<Double> wAcc;
+    protected ArrayList<Double> wErr;
     
     @Override
     public void resetLearningImpl() {
@@ -120,7 +120,18 @@ public class OnlineAdaC2 extends AbstractClassifier implements MultiClassClassif
         this.nEstimators = this.ensembleSizeOption.getValue();        
         this.costPositive = this.costPositiveOption.getValue();
         this.costNegative = this.costNegativeOption.getValue();
-        this.driftDetection = !this.disableDriftDetectionOption.isSet();                
+        this.driftDetection = !this.disableDriftDetectionOption.isSet();
+        this.ensemble = new ArrayList<Classifier>();
+        if (this.driftDetection) {
+            this.adwinEnsemble = new ArrayList<ADWIN>();
+        }
+        this.lambdaTP = new ArrayList<Double>();
+        this.lambdaTN = new ArrayList<Double>();
+        this.lambdaFP = new ArrayList<Double>();
+        this.lambdaFN = new ArrayList<Double>();
+        this.lambdaSum = new ArrayList<Double>();
+        this.wAcc = new ArrayList<Double>();
+        this.wErr = new ArrayList<Double>();
         for (int i = 0; i < this.nEstimators; i++) {
         	this.ensemble.add(this.baseLearner.copy());         	        
         	if (this.driftDetection) {

--- a/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineCSB2.java
+++ b/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineCSB2.java
@@ -99,14 +99,14 @@ public class OnlineCSB2 extends AbstractClassifier implements MultiClassClassifi
     protected double costPositive;
     protected double costNegative;
     protected boolean driftDetection;        
-    protected ArrayList<Classifier> ensemble = new ArrayList<Classifier>();    
-    protected ArrayList<ADWIN> adwinEnsemble = new ArrayList<ADWIN>();    
-    protected ArrayList<Double> lambdaFN = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaFP = new ArrayList<Double>();    
-    protected ArrayList<Double> lambdaSum = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaSw = new ArrayList<Double>();
-    protected ArrayList<Double> epsilon = new ArrayList<Double>();
-    protected ArrayList<Double> wErr = new ArrayList<Double>();     
+    protected ArrayList<Classifier> ensemble;
+    protected ArrayList<ADWIN> adwinEnsemble;
+    protected ArrayList<Double> lambdaFN;
+    protected ArrayList<Double> lambdaFP;
+    protected ArrayList<Double> lambdaSum;
+    protected ArrayList<Double> lambdaSw;
+    protected ArrayList<Double> epsilon;
+    protected ArrayList<Double> wErr;    
     
     @Override
     public void resetLearningImpl() {
@@ -116,7 +116,17 @@ public class OnlineCSB2 extends AbstractClassifier implements MultiClassClassifi
         this.nEstimators = this.ensembleSizeOption.getValue();        
         this.costPositive = this.costPositiveOption.getValue();
         this.costNegative = this.costNegativeOption.getValue();
-        this.driftDetection = !this.disableDriftDetectionOption.isSet();                
+        this.driftDetection = !this.disableDriftDetectionOption.isSet();
+        this.ensemble = new ArrayList<Classifier>();
+        if (this.driftDetection) {
+            this.adwinEnsemble = new ArrayList<ADWIN>();
+        }
+        this.lambdaFN = new ArrayList<Double>();
+        this.lambdaFP = new ArrayList<Double>();
+        this.lambdaSum = new ArrayList<Double>();
+        this.lambdaSw = new ArrayList<Double>();
+        this.epsilon = new ArrayList<Double>();
+        this.wErr = new ArrayList<Double>();
         for (int i = 0; i < this.nEstimators; i++) {
         	this.ensemble.add(this.baseLearner.copy());         	        
         	if (this.driftDetection) {

--- a/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineRUSBoost.java
+++ b/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineRUSBoost.java
@@ -105,13 +105,13 @@ public class OnlineRUSBoost extends AbstractClassifier implements MultiClassClas
     protected int samplingRate;
     protected int algorithmImplementation;
     protected boolean driftDetection;        
-    protected ArrayList<Classifier> ensemble = new ArrayList<Classifier>();    
-    protected ArrayList<ADWIN> adwinEnsemble = new ArrayList<ADWIN>();
-    protected ArrayList<Double> lambdaSc = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaPos = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaNeg = new ArrayList<Double>();
-    protected ArrayList<Double> lambdaSw = new ArrayList<Double>();
-    protected ArrayList<Double> epsilon = new ArrayList<Double>();
+    protected ArrayList<Classifier> ensemble;
+    protected ArrayList<ADWIN> adwinEnsemble;
+    protected ArrayList<Double> lambdaSc;
+    protected ArrayList<Double> lambdaPos;
+    protected ArrayList<Double> lambdaNeg;
+    protected ArrayList<Double> lambdaSw;
+    protected ArrayList<Double> epsilon;
     protected double nPositive;
     protected double nNegative;   
     
@@ -123,7 +123,16 @@ public class OnlineRUSBoost extends AbstractClassifier implements MultiClassClas
         this.nEstimators = this.ensembleSizeOption.getValue();        
         this.samplingRate = this.samplingRateOption.getValue();
         this.algorithmImplementation = this.algorithmImplementationOption.getChosenIndex();
-        this.driftDetection = !this.disableDriftDetectionOption.isSet();                
+        this.driftDetection = !this.disableDriftDetectionOption.isSet();
+        this.ensemble = new ArrayList<Classifier>();
+        if (this.driftDetection) {
+            this.adwinEnsemble = new ArrayList<ADWIN>();
+        }
+        this.lambdaSc = new ArrayList<Double>();
+        this.lambdaPos = new ArrayList<Double>();
+        this.lambdaNeg = new ArrayList<Double>();
+        this.lambdaSw = new ArrayList<Double>();
+        this.epsilon = new ArrayList<Double>();
         for (int i = 0; i < this.nEstimators; i++) {
         	this.ensemble.add(this.baseLearner.copy());         	        
         	if (this.driftDetection) {

--- a/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineSMOTEBagging.java
+++ b/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineSMOTEBagging.java
@@ -99,8 +99,8 @@ public class OnlineSMOTEBagging extends AbstractClassifier implements MultiClass
     protected int nEstimators;    
     protected int samplingRate;    
     protected boolean driftDetection;        
-    protected ArrayList<Classifier> ensemble = new ArrayList<Classifier>();
-    protected ArrayList<ADWIN> adwinEnsemble = new ArrayList<ADWIN>();   
+    protected ArrayList<Classifier> ensemble;
+    protected ArrayList<ADWIN> adwinEnsemble;  
     protected Instances posSamples;
     protected SamoaToWekaInstanceConverter samoaToWeka = new SamoaToWekaInstanceConverter();
     
@@ -111,7 +111,11 @@ public class OnlineSMOTEBagging extends AbstractClassifier implements MultiClass
     	this.baseLearner.resetLearning();
         this.nEstimators = this.ensembleSizeOption.getValue(); 
         this.samplingRate = this.samplingRateOption.getValue();
-        this.driftDetection = !this.disableDriftDetectionOption.isSet();                
+        this.driftDetection = !this.disableDriftDetectionOption.isSet();
+        this.ensemble = new ArrayList<Classifier>();
+        if (this.driftDetection) {
+            this.adwinEnsemble = new ArrayList<ADWIN>();
+        }          
         for (int i = 0; i < this.nEstimators; i++) {
         	this.ensemble.add(this.baseLearner.copy());         	        
         	if (this.driftDetection) {

--- a/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineUnderOverBagging.java
+++ b/moa/src/main/java/moa/classifiers/meta/imbalanced/OnlineUnderOverBagging.java
@@ -98,8 +98,8 @@ public class OnlineUnderOverBagging extends AbstractClassifier implements MultiC
     protected int nEstimators;    
     protected int samplingRate; 
     protected boolean driftDetection;        
-    protected ArrayList<Classifier> ensemble = new ArrayList<Classifier>();    
-    protected ArrayList<ADWIN> adwinEnsemble = new ArrayList<ADWIN>();      
+    protected ArrayList<Classifier> ensemble;
+    protected ArrayList<ADWIN> adwinEnsemble;     
     
     @Override
     public void resetLearningImpl() {
@@ -108,7 +108,11 @@ public class OnlineUnderOverBagging extends AbstractClassifier implements MultiC
     	this.baseLearner.resetLearning();
         this.nEstimators = this.ensembleSizeOption.getValue();        
         this.samplingRate = this.samplingRateOption.getValue();
-        this.driftDetection = !this.disableDriftDetectionOption.isSet();                
+        this.driftDetection = !this.disableDriftDetectionOption.isSet();
+        this.ensemble = new ArrayList<Classifier>();
+        if (this.driftDetection) {
+            this.adwinEnsemble = new ArrayList<ADWIN>();
+        }
         for (int i = 0; i < this.nEstimators; i++) {
         	this.ensemble.add(this.baseLearner.copy());         	        
         	if (this.driftDetection) {


### PR DESCRIPTION
The previous version did not clear the ArrayLists when resetLearning is called, which the ArrayLists will grow if the resetLearning() is invoked for more than once.