### PR TITLE
Update ADWINChangeDetector.java

### DIFF
--- a/moa/src/main/java/moa/classifiers/core/driftdetection/ADWINChangeDetector.java
+++ b/moa/src/main/java/moa/classifiers/core/driftdetection/ADWINChangeDetector.java
@@ -42,6 +42,7 @@ public class ADWINChangeDetector extends AbstractChangeDetector {
 
     @Override
     public void input(double inputValue) {
+        this.isChangeDetected = false;
         if (this.adwin == null) {
             resetLearning();
         }


### PR DESCRIPTION
this.isChangeDetected is never reset after a change is detected

```
if(adwin.setInput(inputValue)) {
            if (this.adwin.getEstimation() > ErrEstim) {
                this.isChangeDetected = true;
            }
        }
```

Therefore, after a drift is detected, code using this class always obtain a "change detected" signal