### PR TITLE
Setup CD MOA docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,53 @@
+name: Publish MOA Docker image
+
+on:
+  push:
+    tags: ['*']
+
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-gha
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: 'master'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push latest image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: "docker/moa-gui.Dockerfile"
+          push: true
+          no-cache: true
+          tags: ghcr.io/waikato/moa:latest
+
+      - name: Build and push devel image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: "docker/devel-gui.Dockerfile"
+          push: true
+          no-cache: true
+          tags: ghcr.io/waikato/moa:devel

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags: ['*']
 
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-gha

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -113,7 +113,9 @@
 * create new release tag on Github (tag version `yyyy.mm.0`, release title `MOA yy.mm.0`) 
   and upload the generated MOA release zip file from the top-level `target` directory 
   and the zip file from the `weka-package/dist` directory
-  
+
+* make sure that the Github action `Publish MOA Docker image` is triggered and ran successfully.
+
 * email Mark Hall (mhall at waikato.ac.nz) the link to the Weka package zip
   file to upload to the central Weka package repository on Sourceforge.net
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,8 @@
 build-latest:
-	    docker build -t waikato/moa:latest -f moa-gui.Dockerfile .
+	    docker build --no-cache -t ghcr.io/waikato/moa:latest -f moa-gui.Dockerfile .
 build-devel:
-	    docker build -t waikato/moa:devel -f devel-gui.Dockerfile .
+	    docker build --no-cache -t ghcr.io/waikato/moa:devel -f devel-gui.Dockerfile .
 push-latest:
-	    docker push waikato/moa:latest
+	    docker push ghcr.io/waikato/moa:latest
 push-devel:
-	    docker push waikato/moa:devel
+	    docker push ghcr.io/waikato/moa:devel

--- a/docker/moa_docker_tutorial.md
+++ b/docker/moa_docker_tutorial.md
@@ -1,7 +1,7 @@
 # Tutorial: Getting Started with MOA Docker
 
 
-Massive Online Analysis (MOA) is also available in Docker. Docker images are located in the ghcr.io/waikato/moa Github Container Registry.
+Massive Online Analysis (MOA) is also available in Docker. Docker images are located in the [ghcr.io/waikato/moa](https://github.com/waikato/moa/pkgs/container/moa) Github Container Registry.
 
 You can download the image and start using MOA. Image releases are tagged using the following format:
 

--- a/docker/moa_docker_tutorial.md
+++ b/docker/moa_docker_tutorial.md
@@ -1,9 +1,7 @@
 # Tutorial: Getting Started with MOA Docker
-by Walid Gara on April 20, 2019 using MOA 2019.04.0
 
 
-
-Massive Online Analysis (MOA) is also available in Docker. Docker images are located in the [waikato/moa](https://hub.docker.com/r/waikato/moa) Docker Hub repository.
+Massive Online Analysis (MOA) is also available in Docker. Docker images are located in the ghcr.io/waikato/moa Github Container Registry.
 
 You can download the image and start using MOA. Image releases are tagged using the following format:
 
@@ -19,7 +17,7 @@ First, you need to install Docker in your machine.
 Download MOA Docker image
 
 ```bash
-$ docker pull waikato/moa:latest
+$ docker pull ghcr.io/waikato/moa:latest
 ```
 
 
@@ -32,7 +30,7 @@ $ xhost +local:root
 Start MOA Docker container.
 
 ```bash
-$ docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" waikato/moa:latest
+$ docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" ghcr.io/waikato/moa:latest
 ```
 
 
@@ -52,7 +50,7 @@ Example of local ip address: `10.42.0.94`
 Then start MOA GUI container where `<ip_address>` is your local ip address.
 
 ```bash
-$ docker run -it --privileged -e DISPLAY=<ip_address>:0.0 -v /tmp/.X11-unix:/tmp/.X11-unix waikato/moa:latest
+$ docker run -it --privileged -e DISPLAY=<ip_address>:0.0 -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/waikato/moa:latest
 ```
 
 
@@ -75,5 +73,5 @@ $ xhost + <ip_address>
 Start MOA GUI container
 
 ```bash
-$ docker run -d -e DISPLAY=<ip_address>:0 -v /tmp/.X11-unix:/tmp/.X11-unix waikato/moa:latest
+$ docker run -d -e DISPLAY=<ip_address>:0 -v /tmp/.X11-unix:/tmp/.X11-unix ghcr.io/waikato/moa:latest
 ```

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,4 +1,7 @@
-## Build MOA Docker images:
+## Build MOA Docker images locally:
+
+You should login to [the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+
 
 Build latest image 
 ```bash


### PR DESCRIPTION
This PR resolves the following points:
- Move the MOA docker image from Docker Hub to Github Container Registry
- Add MOA docker image workflow via Github action, it's triggered when a new tag is pushed. The job will publish both `latest` & `devel` tags.

We need to link the Container Registry to `waikato/moa` repository with write privileges. Please follow these steps in this [Stackoverflow thread](https://stackoverflow.com/a/70992111/11909457).

**This PR was tested in my repository, see the following urls:** 
- [Container Registry](https://github.com/garawalid/moa/pkgs/container/moa)
- [Github workflow execution](https://github.com/garawalid/moa/actions/runs/3048411269/jobs/4913445503)