### PR TITLE
Add PredictionLoggerEvaluator

### DIFF
--- a/moa/src/main/java/moa/evaluation/LearningPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/LearningPerformanceEvaluator.java
@@ -35,7 +35,7 @@ import moa.core.Measurement;
  * @author Richard Kirkby (rkirkby@cs.waikato.ac.nz)
  * @version $Revision: 7 $
  */
-public interface LearningPerformanceEvaluator<E extends Example> extends MOAObject, CapabilitiesHandler {
+public interface LearningPerformanceEvaluator<E extends Example> extends MOAObject, CapabilitiesHandler, AutoCloseable {
 
     /**
      * Resets this evaluator. It must be similar to
@@ -66,4 +66,8 @@ public interface LearningPerformanceEvaluator<E extends Example> extends MOAObje
 	  return new ImmutableCapabilities(Capability.VIEW_STANDARD);
 	}
 
+  @Override
+  default void close() throws Exception {
+    // By default an evaluator does nothing when closed.
+  }
 }

--- a/moa/src/main/java/moa/evaluation/PredictionLoggerEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/PredictionLoggerEvaluator.java
@@ -1,0 +1,160 @@
+package moa.evaluation;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+
+import com.github.javacliparser.FileOption;
+import com.github.javacliparser.FlagOption;
+import com.yahoo.labs.samoa.instances.Instance;
+import com.yahoo.labs.samoa.instances.Prediction;
+
+import moa.capabilities.Capability;
+import moa.capabilities.ImmutableCapabilities;
+import moa.core.Example;
+import moa.core.Measurement;
+import moa.core.ObjectRepository;
+import moa.core.Utils;
+import moa.options.AbstractOptionHandler;
+import moa.options.ClassOption;
+import moa.tasks.TaskMonitor;
+
+public class PredictionLoggerEvaluator extends AbstractOptionHandler
+        implements ClassificationPerformanceEvaluator {
+
+    private static final long serialVersionUID = 1L;
+
+    private OutputStreamWriter writer;
+    private int index = 0;
+
+    public FileOption outputPredictionFileOption = new FileOption("output", 'o',
+            "A file to write comma separated predictions to.", null, "csv.gzip", true);
+
+    public FlagOption overwrite = new FlagOption("overwrite", 'f', "Overwrite existing file.");
+
+    public ClassOption wrappedEvaluatorOption = new ClassOption("evaluator", 'e',
+            "Classification performance evaluation method.", ClassificationPerformanceEvaluator.class,
+            "BasicClassificationPerformanceEvaluator");
+
+    public FlagOption probabilities = new FlagOption("probabilities", 'p',
+            "Log probabilities instead of raw predictions.");
+
+    public FlagOption uncompressed = new FlagOption("uncompressed", 'u',
+            "The output file should be saved uncompressed.");
+
+    private ClassificationPerformanceEvaluator wrappedEvaluator;
+
+    @Override
+    public String getPurposeString() {
+        return "Log raw predictions and probabilities to a CSV file, and evaluate using a wrapped evaluator.";
+    }
+
+    @Override
+    public void addResult(Example<Instance> example, double[] classVotes) {
+        Instance instance = example.getData();
+        int predictedClass = Utils.maxIndex(classVotes);
+        double normalizingFactor = Arrays.stream(classVotes).sum();
+        int numClasses = instance.numClasses();
+
+        if (normalizingFactor == 0) {
+            normalizingFactor = 1;
+        }
+        try {
+            // If this is the first result, write the header to the top of the file
+            if (index == 0)
+                writeHeader(numClasses);
+            
+            
+            // Add row to CSV file
+            if (instance.classIsMissing() == true)
+            {
+                writer.write(String.format("?,%d,", predictedClass));
+            }
+            else
+            {
+                int trueClass = (int) instance.classValue();
+                writer.write(String.format("%d,%d,", trueClass, predictedClass));
+            }
+            
+            if (probabilities.isSet()) {
+                for (int i = 0; i < numClasses; i++) {
+                    double probability = 0.0;
+                    if (i < classVotes.length){
+                        probability = classVotes[i] / normalizingFactor;
+                    }
+                    writer.write(String.format("%.2f,", probability));
+                }
+            }
+
+            writer.write("\n");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // Pass result to wrapped evaluator
+        wrappedEvaluator.addResult(example, classVotes);
+        index ++;
+    }
+
+    @Override
+    public void addResult(Example<Instance> testInst, Prediction prediction) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    protected void prepareForUseImpl(TaskMonitor monitor, ObjectRepository repository) {
+        wrappedEvaluator = (ClassificationPerformanceEvaluator) getPreparedClassOption(wrappedEvaluatorOption);
+        try {
+            File file = outputPredictionFileOption.getFile();
+            if (file.exists() && !overwrite.isSet()) {
+                throw new RuntimeException(
+                        "File already exists: " + file.getAbsolutePath()
+                                + ". MOA doesn't want to overwrite it.");
+            }
+            if (uncompressed.isSet())
+                writer = new OutputStreamWriter(new FileOutputStream(file));
+            else
+                writer = new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(file)));            
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writeHeader(int numClasses) throws IOException {
+        writer.write("true_class,class_prediction,");
+        if (probabilities.isSet()) {
+            for (int i = 0; i < numClasses; i++) {
+                writer.write(String.format("class_probability_%d,", i));
+            }
+        }
+        writer.write("\n");
+    }
+
+    @Override
+    public void close() throws Exception {
+        writer.close();
+    }
+
+    @Override
+    public void reset() {
+        wrappedEvaluator.reset();
+    }
+
+    @Override
+    public Measurement[] getPerformanceMeasurements() {
+        return wrappedEvaluator.getPerformanceMeasurements();
+    }
+
+    @Override
+    public void getDescription(StringBuilder sb, int indent) {
+        sb.append(getPurposeString());
+    }
+
+    @Override
+    public ImmutableCapabilities defineImmutableCapabilities() {
+        return new ImmutableCapabilities(Capability.VIEW_STANDARD);
+    }
+}

--- a/moa/src/main/java/moa/tasks/EvaluateInterleavedChunks.java
+++ b/moa/src/main/java/moa/tasks/EvaluateInterleavedChunks.java
@@ -287,6 +287,11 @@ public class EvaluateInterleavedChunks extends ClassificationMainTask {
 		if (immediateResultStream != null) {
 			immediateResultStream.close();
 		}
+		try {
+			evaluator.close();
+		} catch (Exception ex) {
+			throw new RuntimeException("Exception closing evaluator", ex);
+		}
 		return learningCurve;
 	}
 

--- a/moa/src/main/java/moa/tasks/EvaluateInterleavedTestThenTrain.java
+++ b/moa/src/main/java/moa/tasks/EvaluateInterleavedTestThenTrain.java
@@ -217,6 +217,11 @@ public class EvaluateInterleavedTestThenTrain extends ClassificationMainTask {
         if (immediateResultStream != null) {
             immediateResultStream.close();
         }
+        try {
+            evaluator.close();
+        } catch (Exception ex) {
+            throw new RuntimeException("Exception closing evaluator", ex);
+        }
         return learningCurve;
     }
 

--- a/moa/src/main/java/moa/tasks/EvaluatePeriodicHeldOutTest.java
+++ b/moa/src/main/java/moa/tasks/EvaluatePeriodicHeldOutTest.java
@@ -285,6 +285,11 @@ public class EvaluatePeriodicHeldOutTest extends ClassificationMainTask {
         if (immediateResultStream != null) {
             immediateResultStream.close();
         }
+        try {
+            evaluator.close();
+        } catch (Exception ex) {
+            throw new RuntimeException("Exception closing evaluator", ex);
+        }
         return learningCurve;
     }
 

--- a/moa/src/main/java/moa/tasks/EvaluatePrequentialCV.java
+++ b/moa/src/main/java/moa/tasks/EvaluatePrequentialCV.java
@@ -257,6 +257,12 @@ public class EvaluatePrequentialCV extends ClassificationMainTask {
         if (immediateResultStream != null) {
             immediateResultStream.close();
         }
+        try {
+            for (LearningPerformanceEvaluator evaluator : evaluators)
+                evaluator.close();
+        } catch (Exception ex) {
+            throw new RuntimeException("Exception closing evaluator", ex);
+        }
         return learningCurve;
     }
 

--- a/moa/src/main/java/moa/tasks/EvaluatePrequentialDelayedCV.java
+++ b/moa/src/main/java/moa/tasks/EvaluatePrequentialDelayedCV.java
@@ -282,6 +282,12 @@ public class EvaluatePrequentialDelayedCV extends ClassificationMainTask {
         if (immediateResultStream != null) {
             immediateResultStream.close();
         }
+        try {
+            for (LearningPerformanceEvaluator evaluator : evaluators)
+                evaluator.close();
+        } catch (Exception ex) {
+            throw new RuntimeException("Exception closing evaluator", ex);
+        }
         return learningCurve;
     }
 

--- a/moa/src/main/java/moa/tasks/WriteConfigurationToJupyterNotebook.java
+++ b/moa/src/main/java/moa/tasks/WriteConfigurationToJupyterNotebook.java
@@ -104,7 +104,6 @@ public class WriteConfigurationToJupyterNotebook extends AuxiliarMainTask {
                             learnerString = ((EvaluatePrequential) currentTask).learnerOption.getValueAsCLIString().replace('\\', '/');
                             evaluatorString = ((EvaluatePrequential) currentTask).evaluatorOption.getValueAsCLIString().replace('\\', '/');
                             dumpFile = ((EvaluatePrequential) currentTask).dumpFileOption.getFile();
-                            outputPredictionFile = ((EvaluatePrequential) currentTask).outputPredictionFileOption.getFile();
                             sampleFrequency = ((EvaluatePrequential) currentTask).sampleFrequencyOption.getValue();
                             instanceLimit = ((EvaluatePrequential) currentTask).instanceLimitOption.getValue();
 
@@ -154,7 +153,6 @@ public class WriteConfigurationToJupyterNotebook extends AuxiliarMainTask {
                             learnerString = ((EvaluatePrequentialDelayed) currentTask).learnerOption.getValueAsCLIString().replace('\\', '/');
                             evaluatorString = ((EvaluatePrequentialDelayed) currentTask).evaluatorOption.getValueAsCLIString().replace('\\', '/');
                             dumpFile = ((EvaluatePrequentialDelayed) currentTask).dumpFileOption.getFile();
-                            outputPredictionFile = ((EvaluatePrequentialDelayed) currentTask).outputPredictionFileOption.getFile();
                             sampleFrequency = ((EvaluatePrequentialDelayed) currentTask).sampleFrequencyOption.getValue();
                             instanceLimit = ((EvaluatePrequentialDelayed) currentTask).instanceLimitOption.getValue();
                             trainOnInitialWindow = ((EvaluatePrequentialDelayed) currentTask).trainOnInitialWindowOption.isSet();


### PR DESCRIPTION
- `LearningPerformanceEvaluator` is now `AutoCloseable` to ensure `PredictionLoggerEvaluator` can flush predictions.
- `PredictionLoggerEvaluator` can wrap another `ClassificationPerformanceEvaluator`.
- Removed `outputPredictionFile` from several tasks because it is now redundant.
- Saves a gzip compressed CSV by default.

![MOA GUI with `PredictionLoggerEvaluator`'s default options](https://github.com/Waikato/moa/assets/37557393/5b550dd5-38e1-42c1-8c4d-d784e283b253)

Output with probabilities:
```
true_class,class_prediction,class_probability_0,class_probability_1,
1,0,0.00,0.00,
1,0,0.00,0.00,
0,1,0.00,1.00,
0,1,0.33,0.67,
1,0,0.50,0.50,
0,0,1.00,0.00,
```

Output without probabilities:
```
true_class,class_prediction,
1,0,
1,0,
0,1,
0,1,
1,0,
0,0,
1,1,
```

Some tests fail but I believe these fail on master: 
![Pasted image 20230921134835](https://github.com/Waikato/moa/assets/37557393/314b58a4-19b6-4a21-ab78-c534b323bf53)
