### PR TITLE
fix: window regression evaluation incremental indcies

### DIFF
--- a/moa/src/main/java/moa/evaluation/WindowRegressionPerformanceEvaluator.java
+++ b/moa/src/main/java/moa/evaluation/WindowRegressionPerformanceEvaluator.java
@@ -197,7 +197,7 @@ public class WindowRegressionPerformanceEvaluator extends AbstractOptionHandler
     }
 
     public double getTotalWeightObserved() {
-        return this.weightObserved.total();
+        return this.TotalweightObserved;
     }
 
     public double getMeanError() {


### PR DESCRIPTION
The `instance classified` in window regression evaluation was using the window size.
Now it is incremental.