### PR TITLE
Debugging SRP_MB and Updating the EvaluationTestThanTrain framework

### DIFF
--- a/moa/src/main/java/moa/classifiers/meta/minibatch/StreamingRandomPatchesMB.java
+++ b/moa/src/main/java/moa/classifiers/meta/minibatch/StreamingRandomPatchesMB.java
@@ -287,6 +287,7 @@ public class StreamingRandomPatchesMB extends AbstractClassifierMiniBatch implem
                     break;
                 case StreamingRandomPatchesMB.TRAIN_RANDOM_SUBSPACES:
                 case StreamingRandomPatchesMB.TRAIN_RANDOM_PATCHES:
+                    if (this.subspaces.isEmpty()) break;
                     int selectedValue = this.classifierRandom.nextInt(subspaces.size());
                     ArrayList<Integer> subsetOfFeatures = this.subspaces.get(selectedValue);
                     subsetOfFeatures.add(instance.classIndex());

--- a/moa/src/main/java/moa/tasks/EvaluateInterleavedTestThenTrain.java
+++ b/moa/src/main/java/moa/tasks/EvaluateInterleavedTestThenTrain.java
@@ -25,6 +25,7 @@ import java.io.PrintStream;
 
 import moa.capabilities.Capability;
 import moa.capabilities.ImmutableCapabilities;
+import moa.classifiers.AbstractClassifierMiniBatch;
 import moa.classifiers.Classifier;
 import moa.classifiers.MultiClassClassifier;
 import moa.core.Example;
@@ -216,6 +217,9 @@ public class EvaluateInterleavedTestThenTrain extends ClassificationMainTask {
         }
         if (immediateResultStream != null) {
             immediateResultStream.close();
+        }
+        if (learner instanceof AbstractClassifierMiniBatch) {
+            ((AbstractClassifierMiniBatch) learner).trainingHasEnded();
         }
         return learningCurve;
     }


### PR DESCRIPTION
Debugging `StreamingRandomPatches-MB` to avoid the subspace being 0.
Updating `EvaluationInterleavedTestThanTrain` framework to be able to stop when no instances left.