### PR TITLE
Stochastic Gradient Trees

### DIFF
--- a/moa/src/main/java/moa/classifiers/trees/StochasticGradientTree.java
+++ b/moa/src/main/java/moa/classifiers/trees/StochasticGradientTree.java
@@ -1,3 +1,22 @@
+/*
+ *    StochasticGradientTree.java
+ *    Copyright (C) 2025 University of Waikato, Hamilton, New Zealand
+ *    @author Henry Gouk (henry.gouk@ed.ac.uk)
+ *
+ *    This program is free software; you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation; either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 package moa.classifiers.trees;
 
 import java.io.Serializable;

--- a/moa/src/test/java/moa/classifiers/trees/StochasticGradientTreeTest.java
+++ b/moa/src/test/java/moa/classifiers/trees/StochasticGradientTreeTest.java
@@ -1,0 +1,77 @@
+/*
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * StochasticGradientTreeTest.java
+ * Copyright (C) 2025 University of Waikato, Hamilton, New Zealand
+ */
+package moa.classifiers.trees;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import moa.classifiers.AbstractMultipleRegressorTestCase;
+import moa.classifiers.Classifier;
+import static moa.test.MoaTestCase.runTest;
+
+/**
+ * Tests the StochasticGradientTree classifier.
+ * 
+ * @author  henrygouk (henry dot gouk at ed dot ac dot uk)
+ * @version $Revision$
+ */
+public class StochasticGradientTreeTest
+  extends AbstractMultipleRegressorTestCase {  
+
+  /**
+   * Constructs the test case. Called by subclasses.
+   *
+   * @param name 	the name of the test
+   */
+  public StochasticGradientTreeTest(String name) {
+    super(name);
+    this.setNumberTests(1);
+  }
+
+  /**
+   * Returns the classifier setups to use in the regression test.
+   *
+   * @return		the setups
+   */
+  @Override
+  protected Classifier[] getRegressionClassifierSetups() {
+    return new Classifier[]{
+	new StochasticGradientTree(),
+    };
+  }
+  
+  /**
+   * Returns a test suite.
+   *
+   * @return		the test suite
+   */
+  public static Test suite() {
+    return new TestSuite(StochasticGradientTreeTest.class);
+  }
+
+  /**
+   * Runs the test from commandline.
+   *
+   * @param args	ignored
+   */
+  public static void main(String[] args) {
+    runTest(suite());
+  }
+}
+

--- a/moa/src/test/resources/moa/classifiers/trees/StochasticGradientTree.ref
+++ b/moa/src/test/resources/moa/classifiers/trees/StochasticGradientTree.ref
@@ -1,0 +1,175 @@
+--> regression-out0.arff
+moa.classifiers.trees.StochasticGradientTree -D StochasticGradientTree$EqualWidthDiscretizer
+
+Index
+  100
+Votes
+  0: 0
+Measurements
+  classified instances: 99
+  mean absolute error: 56028.18181818
+  root mean squared error: 85137.43790751
+  relative mean absolute error: 1.61061305
+  relative root mean squared error: 1.30966942
+  coefficient of determination: -0.715234
+  adjusted coefficient of determination: -0.88868463
+Model measurements
+  model training instances: 99
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  200
+Votes
+  0: 0
+Measurements
+  classified instances: 199
+  mean absolute error: 47265.18090452
+  root mean squared error: 69817.86786721
+  relative mean absolute error: 1.48110092
+  relative root mean squared error: 1.34292938
+  coefficient of determination: -0.80345932
+  adjusted coefficient of determination: -0.88933834
+Model measurements
+  model training instances: 199
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  300
+Votes
+  0: 0
+Measurements
+  classified instances: 299
+  mean absolute error: 48236.32107023
+  root mean squared error: 69375.92808845
+  relative mean absolute error: 1.56928896
+  relative root mean squared error: 1.37901758
+  coefficient of determination: -0.90168948
+  adjusted coefficient of determination: -0.96091164
+Model measurements
+  model training instances: 299
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  400
+Votes
+  0: 0
+Measurements
+  classified instances: 399
+  mean absolute error: 50673.56140351
+  root mean squared error: 73529.32444959
+  relative mean absolute error: 1.55890396
+  relative root mean squared error: 1.37130925
+  coefficient of determination: -0.88048906
+  adjusted coefficient of determination: -0.92399652
+Model measurements
+  model training instances: 399
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  500
+Votes
+  0: 0
+Measurements
+  classified instances: 499
+  mean absolute error: 50025.93386774
+  root mean squared error: 71468.82022708
+  relative mean absolute error: 1.57002198
+  relative root mean squared error: 1.39228533
+  coefficient of determination: -0.93845844
+  adjusted coefficient of determination: -0.97413559
+Model measurements
+  model training instances: 499
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  600
+Votes
+  0: 0
+Measurements
+  classified instances: 599
+  mean absolute error: 49782.51252087
+  root mean squared error: 72120.41961195
+  relative mean absolute error: 1.5681514
+  relative root mean squared error: 1.3755696
+  coefficient of determination: -0.89219172
+  adjusted coefficient of determination: -0.92110467
+Model measurements
+  model training instances: 599
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  700
+Votes
+  0: 0
+Measurements
+  classified instances: 699
+  mean absolute error: 49547.66094421
+  root mean squared error: 70804.7753262
+  relative mean absolute error: 1.5754911
+  relative root mean squared error: 1.39375271
+  coefficient of determination: -0.94254662
+  adjusted coefficient of determination: -0.96792096
+Model measurements
+  model training instances: 699
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  800
+Votes
+  0: 0
+Measurements
+  classified instances: 799
+  mean absolute error: 49418.14893617
+  root mean squared error: 70390.85249711
+  relative mean absolute error: 1.56804791
+  relative root mean squared error: 1.39869244
+  coefficient of determination: -0.95634053
+  adjusted coefficient of determination: -0.97865621
+Model measurements
+  model training instances: 799
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  900
+Votes
+  0: 0
+Measurements
+  classified instances: 899
+  mean absolute error: 48734.02558398
+  root mean squared error: 68844.83141194
+  relative mean absolute error: 1.57316979
+  relative root mean squared error: 1.41042876
+  coefficient of determination: -0.98930928
+  adjusted coefficient of determination: -1.00944852
+Model measurements
+  model training instances: 899
+  leaf nodes: 1
+  nodes: 1
+
+Index
+  1000
+Votes
+  0: 0
+Measurements
+  classified instances: 999
+  mean absolute error: 48551.11711712
+  root mean squared error: 68542.68567758
+  relative mean absolute error: 1.56310398
+  relative root mean squared error: 1.4117509
+  coefficient of determination: -0.99304059
+  adjusted coefficient of determination: -1.01117747
+Model measurements
+  model training instances: 999
+  leaf nodes: 1
+  nodes: 1
+
+
+


### PR DESCRIPTION
I have adapted/mostly reimplemented the Stochastic Gradient Tree method from my ACML 2019 paper. This implementation contains a couple of minor enhancements:

- Leaves can have vector valued predictions, so there is no longer a need to do one-vs-rest (or similar) transforms for multiclass problems.
- I implemented the resplit strategy from EFDT. Previously, SGT would do the same approach as EFDT for choosing a split, but it would not reconsider splits as more data became available.
- I removed the gamma regulariser. This did not seem to have much of an impact in practice.
- This implementation is capable of classification, regression, multi-label classification, and multi-target regression without using any problem transformation strategies.