### PR TITLE
Remove DJL dependency in meta/heros

### DIFF
--- a/moa/src/main/java/moa/classifiers/meta/heros/CandPolicy.java
+++ b/moa/src/main/java/moa/classifiers/meta/heros/CandPolicy.java
@@ -41,6 +41,9 @@ public class CandPolicy extends AbstractOptionHandler implements Policy {
         super();
     }
 
+    private static final long serialVersionUID = 1L;
+
+    @Override
     protected void prepareForUseImpl(TaskMonitor taskMonitor, ObjectRepository objectRepository) {
     }
 
@@ -76,6 +79,7 @@ public class CandPolicy extends AbstractOptionHandler implements Policy {
         return action;
     }
 
+    @Override
     public void getDescription(StringBuilder stringBuilder, int i) {
 
     }

--- a/moa/src/main/java/moa/classifiers/meta/heros/Heros.java
+++ b/moa/src/main/java/moa/classifiers/meta/heros/Heros.java
@@ -34,8 +34,6 @@ import moa.options.ClassOption;
 import moa.tasks.TaskMonitor;
 import moa.classifiers.trees.HoeffdingTree;
 import moa.classifiers.lazy.kNN;
-import moa.classifiers.deeplearning.MLP;
-
 import java.util.*;
 
 /**
@@ -273,8 +271,12 @@ public class Heros extends AbstractClassifier implements MultiClassClassifier, C
             resourceCost = (float) ((kNN) model).kOption.getValue();
         }
         // MLP: number of neurons
-        else if (model instanceof MLP) {
-            resourceCost = (float) (((MLP) model).numberOfNeuronsInEachLayerInLog2.getValue() * ((MLP) model).numberOfLayers.getValue());
+//        else if (model instanceof MLP) {
+//            resourceCost = (float) (((MLP) model).numberOfNeuronsInEachLayerInLog2.getValue() * ((MLP) model).numberOfLayers.getValue());
+//        }
+        // If the model is not one of the types checked above, use dynamic resource costs instead.
+        else {
+            dynamicResourceCosts.setValue(true);
         }
         return resourceCost;
     }

--- a/moa/src/main/java/moa/classifiers/meta/heros/Heros.java
+++ b/moa/src/main/java/moa/classifiers/meta/heros/Heros.java
@@ -118,6 +118,9 @@ public class Heros extends AbstractClassifier implements MultiClassClassifier, C
     protected int[] lastAction;
     protected float resourceNormFactor;
 
+    private static final long serialVersionUID = 1L;
+
+
     @Override
     public String getPurposeString() {
         return "Heterogeneous Online Ensemble method with resource-efficient training.";
@@ -281,7 +284,6 @@ public class Heros extends AbstractClassifier implements MultiClassClassifier, C
         return resourceCost;
     }
 
-
     public void prepareForUseImpl(TaskMonitor monitor, ObjectRepository repository) {
         this.samplesSeen = 0;
         this.policy = (Policy) this.getPreparedClassOption(this.policyOption);
@@ -322,6 +324,7 @@ public class Heros extends AbstractClassifier implements MultiClassClassifier, C
         for (int i = 0; i < this.pool.length; i++) {
             this.pool[i].model.resetLearning();
         }
+        this.lastAction = null;
     }
 
     @Override
@@ -387,12 +390,16 @@ public class Heros extends AbstractClassifier implements MultiClassClassifier, C
 
     @Override
     public boolean isRandomizable() {
-        return false;
+        return true;
     }
 
     @Override
     public Capabilities getCapabilities() {
         return super.getCapabilities();
+    }
+
+    public String toString() {
+        return "HEROS ensemble method using a pool of size " + this.pool.length;
     }
 
     public float[] getResourceCostsOfEachModel() {
@@ -416,6 +423,8 @@ public class Heros extends AbstractClassifier implements MultiClassClassifier, C
         private final boolean dynamicResources;
         protected float resourceNormFactor;
         private boolean resetLearnerAfterDrift;
+
+        private static final long serialVersionUID = 1L;
 
         public PoolItem(Classifier model, ADWIN estimator, float resourceCost, boolean dynamicResources,
                         boolean resetLearnerAfterDrift) {

--- a/moa/src/main/java/moa/classifiers/meta/heros/Policy.java
+++ b/moa/src/main/java/moa/classifiers/meta/heros/Policy.java
@@ -43,9 +43,11 @@ import moa.classifiers.meta.heros.Heros.PoolItem;
  */
 public interface Policy {
 
-    IntOption numModelsToTrainOption = new IntOption("numModelsToTrain", 'k', "Number of models to train.", 1, 0, Integer.MAX_VALUE);
+    IntOption numModelsToTrainOption = new IntOption("numModelsToTrain", 'k', "Number of models to train.", 5, 0, Integer.MAX_VALUE);
     FloatOption epsilonOption = new FloatOption("epsilon", 'e', "Probability to choose a random action.", 0.1, 0.0, 1.0);
-    Random random = new Random();
+    IntOption randomSeedOption = new IntOption("randomSeed", 'r', "Seed for random behaviour of the epsilon greedy parameter.", 1);
+
+    Random random = new Random(randomSeedOption.getValue());
 
     default int[] pull(PoolItem[] pool) {
         if (this.numModelsToTrainOption.getValue() <= 0 | this.numModelsToTrainOption.getValue() > pool.length) {

--- a/moa/src/main/java/moa/classifiers/meta/heros/ZetaPolicy.java
+++ b/moa/src/main/java/moa/classifiers/meta/heros/ZetaPolicy.java
@@ -47,9 +47,9 @@ public class ZetaPolicy extends AbstractOptionHandler implements Policy {
 
     public FloatOption zetaOption = new FloatOption("zeta", 'z', "Maximum predictive performance loss to save resources while training.", 0.01, 0.0, 1.0);
 
-    public ZetaPolicy() {
-    }
+    private static final long serialVersionUID = 1L;
 
+    @Override
     protected void prepareForUseImpl(TaskMonitor taskMonitor, ObjectRepository objectRepository) {
 
     }
@@ -95,6 +95,7 @@ public class ZetaPolicy extends AbstractOptionHandler implements Policy {
         return action;
     }
 
+    @Override
     public void getDescription(StringBuilder stringBuilder, int i) {
 
     }

--- a/moa/src/test/java/moa/classifiers/meta/heros/HerosTest.java
+++ b/moa/src/test/java/moa/classifiers/meta/heros/HerosTest.java
@@ -1,10 +1,9 @@
-package moa.classifiers.meta;
+package moa.classifiers.meta.heros;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import moa.classifiers.AbstractMultipleClassifierTestCase;
 import moa.classifiers.Classifier;
-import moa.classifiers.meta.heros.Heros;
 
 /**
  * Tests the Heros classifier.
@@ -17,7 +16,15 @@ public class HerosTest extends AbstractMultipleClassifierTestCase {
 
     @Override
     protected Classifier[] getRegressionClassifierSetups() {
-        return new Classifier[] { new Heros(), };
+        Heros HTest = new Heros();
+        HTest.dynamicResourceCosts.setValue(false);
+        HTest.aggregationOption.setValue(1);
+        HTest.numInstancesToTrainAllModelsOption.setValue(100);
+        HTest.policyOption.setValueViaCLIString("ZetaPolicy -e 0.0");
+
+        return new Classifier[] {
+                HTest,
+        };
     }
 
     public static Test suite() {

--- a/moa/src/test/resources/moa/classifiers/meta/heros/Heros.ref
+++ b/moa/src/test/resources/moa/classifiers/meta/heros/Heros.ref
@@ -1,0 +1,165 @@
+--> classification-out0.arff
+moa.classifiers.meta.heros.Heros -p (ZetaPolicy -e 0.0)
+
+Index
+  10000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 9999
+  classifications correct (percent): 58.96589659
+  Kappa Statistic (percent): -0.15995947
+  Kappa Temporal Statistic (percent): 13.51180438
+  Kappa M Statistic (percent): -0.1953602
+Model measurements
+  model training instances: 9999
+  pool size (models): 10
+  samples seen: 9999
+
+Index
+  20000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 19999
+  classifications correct (percent): 58.2479124
+  Kappa Statistic (percent): -0.07999128
+  Kappa Temporal Statistic (percent): 12.83014928
+  Kappa M Statistic (percent): -0.09590026
+Model measurements
+  model training instances: 19999
+  pool size (models): 10
+  samples seen: 19999
+
+Index
+  30000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 29999
+  classifications correct (percent): 58.34527818
+  Kappa Statistic (percent): -0.05332939
+  Kappa Temporal Statistic (percent): 13.68377426
+  Kappa M Statistic (percent): -0.0640615
+Model measurements
+  model training instances: 29999
+  pool size (models): 10
+  samples seen: 29999
+
+Index
+  40000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 39999
+  classifications correct (percent): 58.17895447
+  Kappa Statistic (percent): -0.03999786
+  Kappa Temporal Statistic (percent): 13.55485505
+  Kappa M Statistic (percent): -0.04784689
+Model measurements
+  model training instances: 39999
+  pool size (models): 10
+  samples seen: 39999
+
+Index
+  50000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 49999
+  classifications correct (percent): 58.19116382
+  Kappa Statistic (percent): -0.03199863
+  Kappa Temporal Statistic (percent): 13.46965808
+  Kappa M Statistic (percent): -0.03828484
+Model measurements
+  model training instances: 49999
+  pool size (models): 10
+  samples seen: 49999
+
+Index
+  60000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 59999
+  classifications correct (percent): 57.98263304
+  Kappa Statistic (percent): -0.02666576
+  Kappa Temporal Statistic (percent): 13.1139066
+  Kappa M Statistic (percent): -0.03174351
+Model measurements
+  model training instances: 59999
+  pool size (models): 10
+  samples seen: 59999
+
+Index
+  70000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 69999
+  classifications correct (percent): 57.83939771
+  Kappa Statistic (percent): -0.0228565
+  Kappa Temporal Statistic (percent): 13.09520304
+  Kappa M Statistic (percent): -0.02711497
+Model measurements
+  model training instances: 69999
+  pool size (models): 10
+  samples seen: 69999
+
+Index
+  80000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 79999
+  classifications correct (percent): 57.84447306
+  Kappa Statistic (percent): -0.0199995
+  Kappa Temporal Statistic (percent): 13.19210276
+  Kappa M Statistic (percent): -0.02372761
+Model measurements
+  model training instances: 79999
+  pool size (models): 10
+  samples seen: 79999
+
+Index
+  90000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 89999
+  classifications correct (percent): 57.85730953
+  Kappa Statistic (percent): -0.01777739
+  Kappa Temporal Statistic (percent): 13.17843653
+  Kappa M Statistic (percent): -0.02109705
+Model measurements
+  model training instances: 89999
+  pool size (models): 10
+  samples seen: 89999
+
+Index
+  100000
+Votes
+  0: 43
+  1: 82
+Measurements
+  classified instances: 99999
+  classifications correct (percent): 57.8095781
+  Kappa Statistic (percent): -0.01599969
+  Kappa Temporal Statistic (percent): 13.08915623
+  Kappa M Statistic (percent): -0.01896544
+Model measurements
+  model training instances: 99999
+  pool size (models): 10
+  samples seen: 99999
+
+
+


### PR DESCRIPTION
Hello, 
I removed the Deep Java Library (DJL) dependency from `Heros.java` by removing the import of `moa.classifiers.deeplearning.MLP`. This avoids platform-specific errors caused by DJL. 
Hope this is helpful.
Best, Kirsten